### PR TITLE
fix(ci): add sbt setup step to integration workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,6 +57,9 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           cache: sbt
 
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Problem

The integration workflow fails with:
```
sbt: command not found
```

## Cause

`setup-java@v4` with `cache: sbt` only caches `~/.sbt` if sbt is already installed—it doesn't install sbt itself. GitHub's Ubuntu runners don't have sbt pre-installed.

## Fix

Add `sbt/setup-sbt@v1` to properly install sbt before the tessellation build step.

---

*Triggered by CI failure notification*