### PR TITLE
fix(ci): copy metagraph jars before docker build

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -113,12 +113,12 @@ jobs:
       - name: Start metagraph cluster
         working-directory: tessellation
         run: |
-          # Build docker image
-          docker build -t constellationnetwork/tessellation:test -f docker/Dockerfile .
-          
-          # Copy metagraph jars (overwrite tessellation's ml0 with ottochain's)
+          # Copy metagraph jars BEFORE docker build (overwrite tessellation's ml0 with ottochain's)
           cp ../ottochain/modules/l0/target/scala-2.13/ottochain-currency-l0-assembly*.jar docker/jars/ml0.jar
           cp ../ottochain/modules/data_l1/target/scala-2.13/ottochain-data-l1-assembly*.jar docker/jars/dl1.jar
+          
+          # Build docker image (needs all jars in place)
+          docker build -t constellationnetwork/tessellation:test -f docker/Dockerfile .
           
           # Generate keys and start cluster
           ./docker/bin/generate-keys.sh


### PR DESCRIPTION
## Problem

The integration test workflow was failing because `docker/jars/dl1.jar` was not found during docker build:

```
#14 [10/18] COPY docker/jars/dl1.jar /tessellation/jars/dl1.jar
#14 ERROR: "/docker/jars/dl1.jar": not found
```

## Root Cause

The jar files were being copied **after** the docker build:

```yaml
# Old (broken) order:
docker build ...  # needs dl1.jar - doesn't exist!
cp ...dl1.jar     # too late
```

## Fix

Move the `cp` commands **before** `docker build` so the build context includes all required files.

Fixes workflow run #21661060190