### PR TITLE
refactor: rename scriptOracles to scripts

### DIFF
--- a/packages/traffic-generator/src/bridge-client.ts
+++ b/packages/traffic-generator/src/bridge-client.ts
@@ -267,7 +267,7 @@ export class BridgeClient {
     ordinal: number;
     state: {
       stateMachines: Record<string, unknown>;
-      scriptOracles: Record<string, unknown>;
+      scripts: Record<string, unknown>;
     };
   }> {
     const url = `${this.ml0Url}/data-application/v1/checkpoint`;
@@ -279,7 +279,7 @@ export class BridgeClient {
       ordinal: number;
       state: {
         stateMachines: Record<string, unknown>;
-        scriptOracles: Record<string, unknown>;
+        scripts: Record<string, unknown>;
       };
     }>;
   }


### PR DESCRIPTION
Aligns with OttoChain Scala rename (PR #7) and SDK rename (PR #2).

Changes traffic-generator checkpoint type to match metagraph response.