### PR TITLE
feat(gateway): integrate Bridge client for mutations

### DIFF
--- a/packages/gateway/src/schema.ts
+++ b/packages/gateway/src/schema.ts
@@ -221,11 +221,16 @@ export const typeDefs = /* GraphQL */ `
   # === Mutations ===
 
   type Mutation {
+    """
+    Register a new agent identity on-chain.
+    Requires privateKey for signing (dev/testing) or signature for verification (production).
+    """
     registerAgent(
       platform: Platform!
       platformUserId: String!
       platformUsername: String
       displayName: String
+      privateKey: String
     ): RegisterResult!
     
     linkPlatform(
@@ -240,14 +245,16 @@ export const typeDefs = /* GraphQL */ `
       fromAddress: String!
       toAddress: String!
       reason: String
-      signature: String!
+      signature: String
+      privateKey: String
     ): AttestationResult!
     
     proposeContract(
       proposerAddress: String!
       counterpartyAddress: String!
       terms: JSON!
-      signature: String!
+      signature: String
+      privateKey: String
     ): ContractResult!
     
     acceptContract(

--- a/packages/shared/src/bridge-client.ts
+++ b/packages/shared/src/bridge-client.ts
@@ -1,0 +1,159 @@
+// Bridge HTTP Client
+// Provides typed interface for calling Bridge service endpoints
+
+import { getConfig } from './config.js';
+
+export interface BridgeResponse<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+export interface BridgeRegisterAgentRequest {
+  privateKey: string;
+  displayName?: string;
+  platform?: string;
+  platformUserId?: string;
+}
+
+export interface BridgeRegisterAgentResponse {
+  fiberId: string;
+  address: string;
+  hash: string;
+  message: string;
+}
+
+export interface BridgeVouchRequest {
+  privateKey: string;
+  targetFiberId: string;
+  fromAddress?: string;
+  reason?: string;
+}
+
+export interface BridgeVouchResponse {
+  hash: string;
+  event: string;
+  targetFiberId: string;
+  from: string;
+}
+
+export interface BridgeProposeContractRequest {
+  privateKey: string;
+  counterpartyAddress: string;
+  terms: Record<string, unknown>;
+  title?: string;
+  description?: string;
+}
+
+export interface BridgeProposeContractResponse {
+  contractId: string;
+  hash: string;
+  proposer: string;
+  counterparty: string;
+}
+
+export interface BridgeContractActionRequest {
+  privateKey: string;
+  contractId: string;
+  proof?: string;
+  reason?: string;
+}
+
+export interface BridgeContractActionResponse {
+  hash: string;
+  contractId: string;
+  action: string;
+}
+
+class BridgeClient {
+  private baseUrl: string;
+
+  constructor() {
+    this.baseUrl = getConfig().BRIDGE_URL;
+  }
+
+  private async request<T>(
+    method: 'GET' | 'POST',
+    path: string,
+    body?: unknown
+  ): Promise<BridgeResponse<T>> {
+    try {
+      const response = await fetch(`${this.baseUrl}${path}`, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      const data = await response.json() as Record<string, unknown>;
+
+      if (!response.ok) {
+        return {
+          success: false,
+          error: (data.error as string) || `Bridge returned ${response.status}`,
+        };
+      }
+
+      return { success: true, data: data as T };
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : 'Bridge request failed',
+      };
+    }
+  }
+
+  // Agent endpoints
+  async registerAgent(req: BridgeRegisterAgentRequest): Promise<BridgeResponse<BridgeRegisterAgentResponse>> {
+    return this.request<BridgeRegisterAgentResponse>('POST', '/agent/register', req);
+  }
+
+  async activateAgent(privateKey: string, fiberId: string): Promise<BridgeResponse<{ hash: string; fiberId: string; status: string }>> {
+    return this.request('POST', '/agent/activate', { privateKey, fiberId });
+  }
+
+  async vouch(req: BridgeVouchRequest): Promise<BridgeResponse<BridgeVouchResponse>> {
+    return this.request<BridgeVouchResponse>('POST', '/agent/vouch', req);
+  }
+
+  async getAgent(fiberId: string): Promise<BridgeResponse<unknown>> {
+    return this.request('GET', `/agent/${fiberId}`);
+  }
+
+  // Contract endpoints
+  async proposeContract(req: BridgeProposeContractRequest): Promise<BridgeResponse<BridgeProposeContractResponse>> {
+    return this.request<BridgeProposeContractResponse>('POST', '/contract/propose', req);
+  }
+
+  async acceptContract(req: BridgeContractActionRequest): Promise<BridgeResponse<BridgeContractActionResponse>> {
+    return this.request<BridgeContractActionResponse>('POST', '/contract/accept', req);
+  }
+
+  async completeContract(req: BridgeContractActionRequest): Promise<BridgeResponse<BridgeContractActionResponse>> {
+    return this.request<BridgeContractActionResponse>('POST', '/contract/complete', req);
+  }
+
+  async rejectContract(req: BridgeContractActionRequest): Promise<BridgeResponse<BridgeContractActionResponse>> {
+    return this.request<BridgeContractActionResponse>('POST', '/contract/reject', req);
+  }
+
+  async disputeContract(req: BridgeContractActionRequest): Promise<BridgeResponse<BridgeContractActionResponse>> {
+    return this.request<BridgeContractActionResponse>('POST', '/contract/dispute', req);
+  }
+
+  // Health check
+  async health(): Promise<BridgeResponse<{ status: string; service: string }>> {
+    return this.request('GET', '/health');
+  }
+}
+
+// Singleton instance
+let bridgeClient: BridgeClient | null = null;
+
+export function getBridgeClient(): BridgeClient {
+  if (!bridgeClient) {
+    bridgeClient = new BridgeClient();
+  }
+  return bridgeClient;
+}
+
+export { BridgeClient };

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -22,6 +22,7 @@ const ConfigSchema = z.object({
   // Service ports
   GATEWAY_PORT: z.coerce.number().default(4000),
   BRIDGE_PORT: z.coerce.number().default(3030),
+  BRIDGE_URL: z.string().url().default('http://localhost:3030'),
   INDEXER_PORT: z.coerce.number().default(3031),
   
   // GL0 polling interval (ms)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,3 +4,4 @@ export * from './types.js';
 export * from './db.js';
 export * from './config.js';
 export * from './redis.js';
+export * from './bridge-client.js';


### PR DESCRIPTION
## Summary
Wire up Gateway GraphQL mutations to call Bridge service for on-chain transactions.

## Changes
- **packages/shared/src/bridge-client.ts** - New typed HTTP client for Bridge API
- **packages/shared/src/config.ts** - Add `BRIDGE_URL` config
- **packages/gateway/src/resolvers.ts** - Implement mutations using BridgeClient
- **packages/gateway/src/schema.ts** - Add optional `privateKey` input to mutations

## Mutations Implemented
| Mutation | Bridge Endpoint |
|----------|----------------|
| `registerAgent` | POST /agent/register |
| `vouch` | POST /agent/vouch |
| `proposeContract` | POST /contract/propose |
| `acceptContract` | POST /contract/accept |
| `rejectContract` | POST /contract/reject |
| `completeContract` | POST /contract/complete |

## Notes
- Mutations require `privateKey` input for now (dev/testing mode)
- Production would use client-side signing + signature verification
- `linkPlatform` mutation left as TODO (needs design for platform verification flow)