### PR TITLE
refactor(traffic-generator): use SDK types for agent/contract states

### DIFF
--- a/packages/traffic-generator/src/high-throughput.ts
+++ b/packages/traffic-generator/src/high-throughput.ts
@@ -201,7 +201,7 @@ export class HighThroughputSimulator {
         address: wallet.address,
         privateKey: wallet.privateKey,
         fiberId: null,
-        state: 'unregistered',
+        state: 'UNREGISTERED',
         fitness: {
           reputation: 10,
           completionRate: 0.5,
@@ -233,11 +233,11 @@ export class HighThroughputSimulator {
       );
       
       agent.fiberId = result.fiberId;
-      agent.state = 'registered';
+      agent.state = 'REGISTERED';
       
       // Activate
       await this.client.activateAgent(wallet.privateKey, result.fiberId);
-      agent.state = 'active';
+      agent.state = 'ACTIVE';
       
       this.agents.set(agent.address, agent);
       this.agentsByFiber.set(result.fiberId, agent);
@@ -465,7 +465,7 @@ export class HighThroughputSimulator {
     if (actor === 'third_party') {
       // Find an agent not in participants
       for (const agent of this.agents.values()) {
-        if (!fiber.participants.includes(agent.address) && agent.state === 'active') {
+        if (!fiber.participants.includes(agent.address) && agent.state === 'ACTIVE') {
           return agent;
         }
       }

--- a/packages/traffic-generator/src/selection.ts
+++ b/packages/traffic-generator/src/selection.ts
@@ -63,7 +63,7 @@ export function selectAgentByFitness(
   excludeAddresses: Set<string> = new Set()
 ): Agent | null {
   const eligible = population.filter(
-    (a) => a.state === 'active' && !excludeAddresses.has(a.address)
+    (a) => a.state === 'ACTIVE' && !excludeAddresses.has(a.address)
   );
   
   if (eligible.length === 0) return null;
@@ -119,7 +119,7 @@ export function selectCounterparty(
 ): Agent | null {
   const eligible = population.filter(
     (a) =>
-      a.state === 'active' &&
+      a.state === 'ACTIVE' &&
       a.address !== proposer.address &&
       !proposer.meta.activeContracts.has(a.address) // Not already in contract
   );
@@ -349,7 +349,7 @@ export function selectForDeath(
   population: Agent[],
   count: number
 ): Agent[] {
-  const eligible = population.filter((a) => a.state === 'active');
+  const eligible = population.filter((a) => a.state === 'ACTIVE');
   if (eligible.length === 0) return [];
   
   // Invert fitness for death selection

--- a/packages/traffic-generator/src/types.ts
+++ b/packages/traffic-generator/src/types.ts
@@ -4,6 +4,44 @@
  * Genetic evolution-inspired model for continuous metagraph traffic simulation.
  */
 
+import {
+  SdkAgentState,
+  SdkContractState,
+} from '@ottochain/shared';
+
+// Re-export SDK types for convenience
+export { SdkAgentState, SdkContractState };
+
+// ============================================================================
+// State Type Helpers
+// ============================================================================
+
+/**
+ * Extract string keys from TypeScript numeric enums
+ */
+export const enumStringKeys = <T extends Record<string, string | number>>(e: T) =>
+  Object.keys(e).filter((k) => isNaN(Number(k))) as [string, ...string[]];
+
+/**
+ * On-chain agent states (from SDK)
+ */
+export type OnChainAgentState = keyof typeof SdkAgentState;
+
+/**
+ * Simulation agent state includes pre-registration state
+ * UNREGISTERED = has wallet but no fiber yet (not on-chain)
+ */
+export type SimulationAgentState = 'UNREGISTERED' | OnChainAgentState;
+
+/**
+ * On-chain contract states (from SDK)
+ */
+export type OnChainContractState = keyof typeof SdkContractState;
+
+// All valid on-chain agent states for validation
+export const ON_CHAIN_AGENT_STATES = enumStringKeys(SdkAgentState);
+export const ON_CHAIN_CONTRACT_STATES = enumStringKeys(SdkContractState);
+
 // ============================================================================
 // Agent Population Types
 // ============================================================================
@@ -13,10 +51,10 @@ export interface Agent {
   address: string;
   /** Private key for signing */
   privateKey: string;
-  /** Agent identity fiber ID */
+  /** Agent identity fiber ID (null if UNREGISTERED) */
   fiberId: string | null;
   /** Current state in the identity lifecycle */
-  state: AgentState;
+  state: SimulationAgentState;
   /** Computed fitness score */
   fitness: AgentFitness;
   /** Simulation metadata */
@@ -57,15 +95,6 @@ export interface AgentMeta {
   riskTolerance: number;
 }
 
-export type AgentState = 
-  | 'unregistered'  // Has wallet but no fiber yet
-  | 'registered'    // Fiber created, awaiting activation
-  | 'active'        // Fully active agent
-  | 'challenged'    // Under challenge
-  | 'suspended'     // Challenge upheld
-  | 'probation'     // Recovering from suspension
-  | 'withdrawn';    // Final state
-
 // ============================================================================
 // Contract Types
 // ============================================================================
@@ -78,7 +107,7 @@ export interface Contract {
   /** Counterparty agent address */
   counterparty: string;
   /** Current contract state */
-  state: ContractState;
+  state: OnChainContractState;
   /** Task description */
   task: string;
   /** Contract terms */
@@ -88,13 +117,6 @@ export interface Contract {
   /** Expected completion generation */
   expectedCompletion: number;
 }
-
-export type ContractState =
-  | 'proposed'
-  | 'active'
-  | 'completed'
-  | 'rejected'
-  | 'disputed';
 
 // ============================================================================
 // Simulation Context


### PR DESCRIPTION
## Summary
Phase 2 of SDK type unification: Update traffic-generator to use SDK protobuf types.

## Changes
- Import `AgentState` and `ContractState` from `@ottochain/shared` (which re-exports from SDK)
- Create `SimulationAgentState` type that extends SDK states with `UNREGISTERED` for pre-chain agents
- Standardize all state values to uppercase (matching SDK enum names)
- Export `enumStringKeys` helper for working with numeric enums
- Update all usages in:
  - `simulator.ts`
  - `high-throughput.ts`
  - `selection.ts`

## Type Mapping
| Old (lowercase) | New (SDK) |
|----------------|-----------|
| `unregistered` | `UNREGISTERED` (sim-only) |
| `registered` | `REGISTERED` |
| `active` | `ACTIVE` |
| `challenged` | `CHALLENGED` |
| `suspended` | `SUSPENDED` |
| `probation` | `PROBATION` |
| `withdrawn` | `WITHDRAWN` |
| `proposed` | `PROPOSED` |
| `completed` | `COMPLETED` |
| `rejected` | `REJECTED` |
| `disputed` | `DISPUTED` |

## Breaking Change
State values are now uppercase strings matching SDK enum names.

## Migration Plan
- [x] Phase 1: shared (done in #13)
- [x] **Phase 2: traffic-generator** ← this PR
- [ ] Phase 3: bridge
- [ ] Phase 4: indexer