### PR TITLE
refactor(indexer): align Prisma schema with SDK protobuf types

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -190,8 +190,12 @@ model SnapshotSubscriber {
 }
 
 enum AgentState {
+  UNSPECIFIED
   REGISTERED
   ACTIVE
+  CHALLENGED
+  SUSPENDED
+  PROBATION
   WITHDRAWN
 }
 
@@ -211,9 +215,11 @@ enum AttestationType {
 }
 
 enum ContractState {
+  UNSPECIFIED
   PROPOSED
   ACTIVE
   COMPLETED
   REJECTED
   DISPUTED
+  CANCELLED
 }


### PR DESCRIPTION
## Summary
Phase 4 of SDK type unification: Update Prisma schema and indexer to use SDK-aligned state enums.

## Changes

### Prisma Schema
Added missing states to match SDK protobuf definitions:

**AgentState:**
| Before | After |
|--------|-------|
| REGISTERED | UNSPECIFIED |
| ACTIVE | REGISTERED |
| WITHDRAWN | ACTIVE |
| | CHALLENGED |
| | SUSPENDED |
| | PROBATION |
| | WITHDRAWN |

**ContractState:**
| Before | After |
|--------|-------|
| PROPOSED | UNSPECIFIED |
| ACTIVE | PROPOSED |
| COMPLETED | ACTIVE |
| REJECTED | COMPLETED |
| DISPUTED | REJECTED |
| | DISPUTED |
| | CANCELLED |

### Indexer
- Updated `mapAgentState()` to use Prisma enum directly with full state mapping
- Updated `mapContractState()` to use Prisma enum directly with full state mapping
- Import Prisma enum types for type-safe database operations

## Breaking Change
Requires database migration for new enum values.

```sql
ALTER TYPE "AgentState" ADD VALUE 'UNSPECIFIED';
ALTER TYPE "AgentState" ADD VALUE 'CHALLENGED';
ALTER TYPE "AgentState" ADD VALUE 'SUSPENDED';
ALTER TYPE "AgentState" ADD VALUE 'PROBATION';

ALTER TYPE "ContractState" ADD VALUE 'UNSPECIFIED';
ALTER TYPE "ContractState" ADD VALUE 'CANCELLED';
```

## Migration Plan
- [x] Phase 1: shared (done in #13)
- [x] Phase 2: traffic-generator (#15)
- [ ] Phase 3: bridge (skipped - defines source of truth for on-chain states)
- [x] **Phase 4: indexer** ← this PR