### PR TITLE
feat: add ML0 watchdog for auto-restart on CPU starvation

### DIFF
--- a/scripts/watchdog/README.md
+++ b/scripts/watchdog/README.md
@@ -1,0 +1,81 @@
+# Metagraph Watchdog Scripts
+
+Auto-restart scripts for metagraph nodes that become unresponsive due to CPU starvation.
+
+## Problem
+
+Under heavy load (e.g., high traffic generator volume), ML0 can experience CPU starvation where:
+- Container shows "Up" in Docker
+- But HTTP health endpoint (`/node/info`) times out
+- Cats Effect runtime is too busy to schedule HTTP handlers
+- Consensus shows "process is stale" warnings
+
+The node is technically running but functionally dead.
+
+## Solution
+
+`ml0-watchdog.sh` monitors the health endpoint and restarts the container after consecutive failures.
+
+## Installation
+
+### Option 1: Cron (Recommended)
+
+```bash
+# Copy to tessellation server
+scp scripts/watchdog/ml0-watchdog.sh root@<METAGRAPH_IP>:/opt/ottochain/scripts/
+
+# Make executable
+ssh root@<METAGRAPH_IP> "chmod +x /opt/ottochain/scripts/ml0-watchdog.sh"
+
+# Add to crontab (checks every minute)
+ssh root@<METAGRAPH_IP> 'echo "* * * * * /opt/ottochain/scripts/ml0-watchdog.sh >> /var/log/ml0-watchdog.log 2>&1" | crontab -'
+```
+
+### Option 2: Daemon Mode
+
+```bash
+# Run in background
+nohup ./ml0-watchdog.sh --daemon >> /var/log/ml0-watchdog.log 2>&1 &
+```
+
+### Option 3: Systemd
+
+```ini
+# /etc/systemd/system/ml0-watchdog.service
+[Unit]
+Description=ML0 Watchdog
+After=docker.service
+
+[Service]
+Type=simple
+ExecStart=/opt/ottochain/scripts/ml0-watchdog.sh --daemon
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Configuration
+
+Environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ML0_PORT` | `9200` | ML0 HTTP port |
+| `ML0_CONTAINER` | `ml0` | Docker container name |
+| `TIMEOUT_SECONDS` | `10` | Health check timeout |
+| `MAX_FAILURES` | `3` | Consecutive failures before restart |
+| `DAEMON_INTERVAL` | `60` | Seconds between checks (daemon mode) |
+
+## Logs
+
+Check `/var/log/ml0-watchdog.log` or `journalctl -t ml0-watchdog` for activity.
+
+Example output:
+```
+[2026-02-06 19:05:23] WARN: ML0 health check failed (attempt 1/3)
+[2026-02-06 19:06:23] WARN: ML0 health check failed (attempt 2/3)
+[2026-02-06 19:07:23] WARN: ML0 health check failed (attempt 3/3)
+[2026-02-06 19:07:23] ERROR: ML0 unresponsive after 3 attempts, restarting...
+[2026-02-06 19:07:25] INFO: ML0 restart initiated successfully
+```

--- a/scripts/watchdog/ml0-watchdog.sh
+++ b/scripts/watchdog/ml0-watchdog.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# ml0-watchdog.sh - Restart ML0 if unresponsive due to CPU starvation
+#
+# Symptoms this catches:
+# - Container shows "Up" but HTTP endpoint times out
+# - CPU starvation causes Cats Effect to not schedule HTTP handlers
+# - Consensus stalls with "process is stale" warnings
+#
+# Usage:
+#   ./ml0-watchdog.sh              # Single check
+#   ./ml0-watchdog.sh --daemon     # Run continuously (every 60s)
+#
+# Install as cron (recommended):
+#   * * * * * /opt/ottochain/scripts/ml0-watchdog.sh >> /var/log/ml0-watchdog.log 2>&1
+
+set -euo pipefail
+
+# Configuration
+ML0_PORT="${ML0_PORT:-9200}"
+ML0_CONTAINER="${ML0_CONTAINER:-ml0}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-10}"
+FAILURE_FILE="/tmp/ml0-watchdog-failures"
+MAX_FAILURES="${MAX_FAILURES:-3}"
+DAEMON_INTERVAL="${DAEMON_INTERVAL:-60}"
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+    logger -t ml0-watchdog "$*" 2>/dev/null || true
+}
+
+check_ml0() {
+    # Check if container is running
+    if ! docker ps --format '{{.Names}}' | grep -q "^${ML0_CONTAINER}$"; then
+        log "INFO: ML0 container not running, skipping check"
+        rm -f "$FAILURE_FILE"
+        return 0
+    fi
+
+    # Try to reach health endpoint
+    if curl -sf --max-time "$TIMEOUT_SECONDS" "http://localhost:${ML0_PORT}/node/info" >/dev/null 2>&1; then
+        # Success - reset failure counter
+        if [[ -f "$FAILURE_FILE" ]]; then
+            log "INFO: ML0 recovered, clearing failure counter"
+            rm -f "$FAILURE_FILE"
+        fi
+        return 0
+    fi
+
+    # Failed - increment counter
+    local failures=0
+    if [[ -f "$FAILURE_FILE" ]]; then
+        failures=$(cat "$FAILURE_FILE")
+    fi
+    failures=$((failures + 1))
+    echo "$failures" > "$FAILURE_FILE"
+
+    log "WARN: ML0 health check failed (attempt $failures/$MAX_FAILURES)"
+
+    # Check if we've hit the threshold
+    if [[ $failures -ge $MAX_FAILURES ]]; then
+        log "ERROR: ML0 unresponsive after $failures attempts, restarting..."
+        
+        # Restart the container
+        if docker restart "$ML0_CONTAINER"; then
+            log "INFO: ML0 restart initiated successfully"
+            rm -f "$FAILURE_FILE"
+            
+            # Optional: send alert (uncomment if TELEGRAM vars are set)
+            # if [[ -n "${TELEGRAM_BOT_TOKEN:-}" ]] && [[ -n "${TELEGRAM_CHAT_ID:-}" ]]; then
+            #     curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            #         -d "chat_id=${TELEGRAM_CHAT_ID}" \
+            #         -d "text=🔄 ML0 was unresponsive and has been restarted" >/dev/null
+            # fi
+        else
+            log "ERROR: Failed to restart ML0"
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
+# Main
+if [[ "${1:-}" == "--daemon" ]]; then
+    log "INFO: Starting ML0 watchdog daemon (interval: ${DAEMON_INTERVAL}s)"
+    while true; do
+        check_ml0 || true
+        sleep "$DAEMON_INTERVAL"
+    done
+else
+    check_ml0
+fi


### PR DESCRIPTION
## Problem

Under heavy traffic generator load, ML0 experiences CPU starvation:
- Container shows `Up` in Docker
- HTTP endpoint (`/node/info`) times out
- Cats Effect runtime too busy to schedule HTTP handlers
- Consensus shows "process is stale" warnings
- Node is technically running but functionally dead

## Solution

`ml0-watchdog.sh` monitors the health endpoint and restarts after consecutive failures.

## Features

- **Single-run mode** for cron (recommended)
- **Daemon mode** with configurable interval  
- **Consecutive failure tracking** (avoids restart on transient issues)
- **Configurable** via environment variables
- **Logs** to syslog and stdout

## Configuration

| Variable | Default | Description |
|----------|---------|-------------|
| `ML0_PORT` | `9200` | ML0 HTTP port |
| `ML0_CONTAINER` | `ml0` | Docker container name |
| `TIMEOUT_SECONDS` | `10` | Health check timeout |
| `MAX_FAILURES` | `3` | Consecutive failures before restart |

## Installation

```bash
# Copy to tessellation server and add to cron
scp scripts/watchdog/ml0-watchdog.sh root@<METAGRAPH_IP>:/opt/ottochain/scripts/
ssh root@<METAGRAPH_IP> 'chmod +x /opt/ottochain/scripts/ml0-watchdog.sh'
ssh root@<METAGRAPH_IP> 'echo "* * * * * /opt/ottochain/scripts/ml0-watchdog.sh >> /var/log/ml0-watchdog.log 2>&1" | crontab -'
```

## Context

This addresses the ML0 unresponsiveness observed when traffic generator was running at high volume (ML0 at 723% CPU, health checks timing out).