### PR TITLE
fix: improve Redis URL configuration handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@
 # ============ Database ============
 DATABASE_URL=postgresql://ottochain:YOUR_PASSWORD@localhost:5432/ottochain_identity
 
+# ============ Redis ============
+REDIS_URL=redis://localhost:6379
+
 # ============ Tessellation Endpoints ============
 # Set these to your metagraph node IPs
 GL0_URL=http://YOUR_METAGRAPH_IP:9000

--- a/packages/gateway/src/pubsub.ts
+++ b/packages/gateway/src/pubsub.ts
@@ -1,13 +1,8 @@
 import { RedisPubSub } from 'graphql-redis-subscriptions';
 import Redis from 'ioredis';
-import { getConfig } from '@ottochain/shared';
+import { getRedisOptions } from '@ottochain/shared';
 
-const config = getConfig();
-
-const options = {
-  host: new URL(config.REDIS_URL).hostname,
-  port: parseInt(new URL(config.REDIS_URL).port || '6379'),
-};
+const options = getRedisOptions();
 
 export const pubsub = new RedisPubSub({
   publisher: new Redis(options),


### PR DESCRIPTION
## Summary
Fixes Redis URL configuration to be more robust and discoverable.

## Changes
- **Add REDIS_URL to .env.example** - Makes the config var discoverable for new deployments
- **Custom Zod validator** - Properly validates redis:// and rediss:// URLs (standard URL validation may reject them)
- **getRedisOptions() helper** - Centralized URL parsing for consistent behavior
- **TLS support** - Detects rediss:// protocol and enables TLS automatically

## Files Changed
- `.env.example` - Added REDIS_URL
- `packages/shared/src/config.ts` - Custom validator + helper function
- `packages/gateway/src/pubsub.ts` - Simplified to use shared helper