### PR TITLE
fix(traffic-gen): add transitions array to MARKET_SM_DEFINITION

### DIFF
--- a/packages/traffic-generator/src/market-workflows.ts
+++ b/packages/traffic-generator/src/market-workflows.ts
@@ -31,6 +31,23 @@ export const MARKET_SM_DEFINITION = {
     CANCELLED: { id: { value: 'CANCELLED' }, isFinal: true },
   },
   initialState: { value: 'PROPOSED' },
+  transitions: [
+    // PROPOSED transitions
+    { eventName: 'open', from: { value: 'PROPOSED' }, to: { value: 'OPEN' } },
+    { eventName: 'cancel', from: { value: 'PROPOSED' }, to: { value: 'CANCELLED' } },
+    // OPEN transitions
+    { eventName: 'commit', from: { value: 'OPEN' }, to: { value: 'OPEN' } }, // Self-loop for commits
+    { eventName: 'close', from: { value: 'OPEN' }, to: { value: 'CLOSED' } },
+    // CLOSED transitions
+    { eventName: 'submit_resolution', from: { value: 'CLOSED' }, to: { value: 'RESOLVING' } },
+    { eventName: 'refund', from: { value: 'CLOSED' }, to: { value: 'REFUNDED' } },
+    // RESOLVING transitions
+    { eventName: 'submit_resolution', from: { value: 'RESOLVING' }, to: { value: 'RESOLVING' } }, // Additional oracles
+    { eventName: 'finalize', from: { value: 'RESOLVING' }, to: { value: 'SETTLED' } },
+    { eventName: 'refund', from: { value: 'RESOLVING' }, to: { value: 'REFUNDED' } },
+    // SETTLED transitions (claims don't change state, just distribute)
+    { eventName: 'claim', from: { value: 'SETTLED' }, to: { value: 'SETTLED' } },
+  ],
 };
 
 // ============================================================================


### PR DESCRIPTION
## Problem
Market creation was failing with 400 validation errors:
```
❌ Market creation failed: POST /fiber/create failed: 400 {"error":"Invalid request"...
```

## Root Cause
The `sm.ts` route requires a `transitions` array in the state machine definition schema:
```typescript
definition: z.object({
  metadata: z.object({...}),
  states: z.record(z.any()),
  initialState: z.object({ value: z.string() }),
  transitions: z.array(z.any()),  // ← Required!
})
```

But `MARKET_SM_DEFINITION` only had `metadata`, `states`, and `initialState`.

## Fix
Added the full transitions array covering all valid market state transitions:
- PROPOSED → OPEN / CANCELLED
- OPEN → OPEN (commit self-loop) / CLOSED
- CLOSED → RESOLVING / REFUNDED
- RESOLVING → RESOLVING (oracle self-loop) / SETTLED / REFUNDED
- SETTLED → SETTLED (claim self-loop)

## Testing
Build passes. Traffic generator should now be able to create market fibers.