### PR TITLE
feat: add release workflow and Dockerfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,120 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 1.2.3)'
+        required: true
+        type: string
+      bump:
+        description: 'Or auto-bump from latest tag'
+        required: false
+        type: choice
+        options:
+          - ''
+          - patch
+          - minor
+          - major
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  release:
+    name: Build & Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            # Get latest tag and bump
+            LATEST=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+            LATEST="${LATEST#v}"
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST"
+            
+            case "${{ inputs.bump }}" in
+              major) VERSION="$((MAJOR+1)).0.0" ;;
+              minor) VERSION="${MAJOR}.$((MINOR+1)).0" ;;
+              patch) VERSION="${MAJOR}.${MINOR}.$((PATCH+1))" ;;
+              *) echo "::error::Specify version or bump type"; exit 1 ;;
+            esac
+          fi
+          
+          echo "version=v${VERSION#v}" >> $GITHUB_OUTPUT
+          echo "Releasing version: v${VERSION#v}"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Run tests
+        run: pnpm run test
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+      - name: Create git tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.version.outputs.version }}"
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          if [ -n "$PREV_TAG" ]; then
+            echo "## Changes since $PREV_TAG" > changelog.md
+            git log --pretty=format:"- %s (%h)" "$PREV_TAG"..HEAD >> changelog.md
+          else
+            echo "## Initial Release" > changelog.md
+            git log --pretty=format:"- %s (%h)" >> changelog.md
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          name: Release ${{ steps.version.outputs.version }}
+          body_path: changelog.md
+          generate_release_notes: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Build stage
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Install pnpm
+RUN corepack enable && corepack prepare pnpm@8 --activate
+
+# Copy package files
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/gateway/package.json ./packages/gateway/
+COPY packages/bridge/package.json ./packages/bridge/
+COPY packages/indexer/package.json ./packages/indexer/
+COPY packages/monitor/package.json ./packages/monitor/
+COPY packages/traffic-generator/package.json ./packages/traffic-generator/
+COPY packages/shared/package.json ./packages/shared/
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile
+
+# Copy source
+COPY . .
+
+# Generate Prisma client
+RUN pnpm --filter indexer prisma generate
+
+# Build all packages
+RUN pnpm run build
+
+# Production stage
+FROM node:20-alpine AS production
+
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@8 --activate
+
+# Copy built artifacts
+COPY --from=builder /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml ./
+COPY --from=builder /app/packages ./packages
+COPY --from=builder /app/node_modules ./node_modules
+
+# Default to gateway, override with command
+ENV SERVICE=gateway
+ENV NODE_ENV=production
+
+EXPOSE 4000 3030 3031 3032
+
+CMD ["sh", "-c", "pnpm --filter $SERVICE start"]


### PR DESCRIPTION
## Release Workflow

Manual trigger to build and release packages to ghcr.io.

### Usage

```bash
# Explicit version
gh workflow run release.yml -f version=1.0.0

# Auto-bump from latest tag
gh workflow run release.yml -f bump=patch   # 1.0.0 → 1.0.1
gh workflow run release.yml -f bump=minor   # 1.0.0 → 1.1.0
gh workflow run release.yml -f bump=major   # 1.0.0 → 2.0.0
```

### What it does
1. Checkout + install deps
2. Build all packages
3. Run tests
4. Build Docker image
5. Push to `ghcr.io/ottobot-ai/ottochain-services:vX.Y.Z` + `:latest`
6. Create git tag
7. Create GitHub Release with changelog

### Dockerfile
Multi-stage build, runs any service via `SERVICE=gateway` env var.