### PR TITLE
fix: align with SDK ts-proto breaking changes

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,92 @@
+services:
+  gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "4000:4000"
+    environment:
+      SERVICE: gateway
+      DATABASE_URL: postgresql://ottochain:ottochain@postgres:5432/ottochain_identity
+      METAGRAPH_ML0_URL: http://host.docker.internal:9200
+      METAGRAPH_DL1_URL: http://host.docker.internal:9400
+      GATEWAY_PORT: 4000
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - ottochain
+
+  bridge:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3030:3030"
+    environment:
+      SERVICE: bridge
+      DATABASE_URL: postgresql://ottochain:ottochain@postgres:5432/ottochain_identity
+      METAGRAPH_ML0_URL: http://host.docker.internal:9200
+      METAGRAPH_DL1_URL: http://host.docker.internal:9400
+      BRIDGE_PORT: 3030
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - ottochain
+
+  indexer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3031:3031"
+    environment:
+      SERVICE: indexer
+      DATABASE_URL: postgresql://ottochain:ottochain@postgres:5432/ottochain_identity
+      METAGRAPH_ML0_URL: http://host.docker.internal:9200
+      METAGRAPH_DL1_URL: http://host.docker.internal:9400
+      INDEXER_PORT: 3031
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - ottochain
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    networks:
+      - ottochain
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ottochain
+      POSTGRES_PASSWORD: ottochain
+      POSTGRES_DB: ottochain_identity
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ottochain"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - ottochain
+
+volumes:
+  postgres_data:
+
+networks:
+  ottochain:
+    driver: bridge

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@ottochain/shared": "workspace:*",
-    "@ottochain/sdk": "github:ottobot-ai/ottochain-sdk#309b6ec",
+    "@ottochain/sdk": "github:ottobot-ai/ottochain-sdk#main",
     "@stardust-collective/dag4": "^2.8.1",
     "canonicalize": "^2.1.0",
     "express": "^4.18.0",

--- a/packages/bridge/src/routes/governance.ts
+++ b/packages/bridge/src/routes/governance.ts
@@ -17,11 +17,8 @@ import {
 import {
   getDAODefinition,
   getGovernanceDefinition,
-  createMultisigState,
-  createTokenState,
-  createSingleOwnerState,
-  type DAOType,
-  type GovernanceType,
+  type DAODefinitionType,
+  type GovernanceDefinitionType,
 } from '@ottochain/sdk/apps/governance';
 
 export const governanceRoutes: RouterType = Router();

--- a/packages/bridge/src/routes/market.ts
+++ b/packages/bridge/src/routes/market.ts
@@ -16,21 +16,22 @@ export const marketRoutes: RouterType = Router();
 
 // Map proto enum to API-friendly lowercase strings
 const MARKET_TYPE_MAP: Record<string, MarketType> = {
-  prediction: MarketType.PREDICTION,
-  auction: MarketType.AUCTION,
-  crowdfund: MarketType.CROWDFUND,
-  group_buy: MarketType.GROUP_BUY,
+  prediction: MarketType.MARKET_TYPE_PREDICTION,
+  auction: MarketType.MARKET_TYPE_AUCTION,
+  crowdfund: MarketType.MARKET_TYPE_CROWDFUND,
+  group_buy: MarketType.MARKET_TYPE_GROUP_BUY,
 };
 
 const MARKET_STATE_MAP: Record<MarketState, string> = {
-  [MarketState.UNSPECIFIED]: 'UNSPECIFIED',
-  [MarketState.PROPOSED]: 'PROPOSED',
-  [MarketState.OPEN]: 'OPEN',
-  [MarketState.CLOSED]: 'CLOSED',
-  [MarketState.RESOLVING]: 'RESOLVING',
-  [MarketState.SETTLED]: 'SETTLED',
-  [MarketState.REFUNDED]: 'REFUNDED',
-  [MarketState.CANCELLED]: 'CANCELLED',
+  [MarketState.MARKET_STATE_UNSPECIFIED]: 'UNSPECIFIED',
+  [MarketState.MARKET_STATE_PROPOSED]: 'PROPOSED',
+  [MarketState.MARKET_STATE_OPEN]: 'OPEN',
+  [MarketState.MARKET_STATE_CLOSED]: 'CLOSED',
+  [MarketState.MARKET_STATE_RESOLVING]: 'RESOLVING',
+  [MarketState.MARKET_STATE_SETTLED]: 'SETTLED',
+  [MarketState.MARKET_STATE_REFUNDED]: 'REFUNDED',
+  [MarketState.MARKET_STATE_CANCELLED]: 'CANCELLED',
+  [MarketState.UNRECOGNIZED]: 'UNRECOGNIZED',
 };
 
 // ============================================================================
@@ -155,7 +156,7 @@ marketRoutes.post('/create', async (req, res) => {
       resolutions: [],
       claims: {},
       status: 'PROPOSED',
-      statusProto: MarketState.PROPOSED,
+      statusProto: MarketState.MARKET_STATE_PROPOSED,
       createdAt: new Date().toISOString(),
     };
 
@@ -234,7 +235,7 @@ marketRoutes.post('/open', async (req, res) => {
       hash: result.hash,
       marketId: input.marketId,
       status: 'OPEN',
-      statusProto: MarketState.OPEN,
+      statusProto: MarketState.MARKET_STATE_OPEN,
     });
   } catch (err) {
     if (err instanceof z.ZodError) {
@@ -336,7 +337,7 @@ marketRoutes.post('/close', async (req, res) => {
       hash: result.hash,
       marketId: input.marketId,
       status: 'CLOSED',
-      statusProto: MarketState.CLOSED,
+      statusProto: MarketState.MARKET_STATE_CLOSED,
     });
   } catch (err) {
     if (err instanceof z.ZodError) {
@@ -442,7 +443,7 @@ marketRoutes.post('/finalize', async (req, res) => {
       hash: result.hash,
       marketId: input.marketId,
       status: 'SETTLED',
-      statusProto: MarketState.SETTLED,
+      statusProto: MarketState.MARKET_STATE_SETTLED,
       outcome: input.outcome,
     });
   } catch (err) {
@@ -562,7 +563,7 @@ marketRoutes.post('/refund', async (req, res) => {
       hash: result.hash,
       marketId: input.marketId,
       status: 'REFUNDED',
-      statusProto: MarketState.REFUNDED,
+      statusProto: MarketState.MARKET_STATE_REFUNDED,
     });
   } catch (err) {
     if (err instanceof z.ZodError) {
@@ -614,7 +615,7 @@ marketRoutes.post('/cancel', async (req, res) => {
       hash: result.hash,
       marketId: input.marketId,
       status: 'CANCELLED',
-      statusProto: MarketState.CANCELLED,
+      statusProto: MarketState.MARKET_STATE_CANCELLED,
     });
   } catch (err) {
     if (err instanceof z.ZodError) {

--- a/packages/traffic-generator/src/high-throughput.ts
+++ b/packages/traffic-generator/src/high-throughput.ts
@@ -12,7 +12,7 @@ import type {
   GenerationStats,
   AgentFitness,
 } from './types.js';
-import { DEFAULT_CONFIG } from './types.js';
+import { DEFAULT_CONFIG, SdkAgentState as AgentState } from './types.js';
 import { BridgeClient } from './bridge-client.js';
 import {
   computeFitness,
@@ -242,11 +242,11 @@ export class HighThroughputSimulator {
       );
       
       agent.fiberId = result.fiberId;
-      agent.state = 'REGISTERED';
+      agent.state = AgentState.AGENT_STATE_REGISTERED;
       
       // Activate
       await this.client.activateAgent(wallet.privateKey, result.fiberId);
-      agent.state = 'ACTIVE';
+      agent.state = AgentState.AGENT_STATE_ACTIVE;
       
       this.agents.set(agent.address, agent);
       this.agentsByFiber.set(result.fiberId, agent);
@@ -474,7 +474,7 @@ export class HighThroughputSimulator {
     if (actor === 'third_party') {
       // Find an agent not in participants
       for (const agent of this.agents.values()) {
-        if (!fiber.participants.includes(agent.address) && agent.state === 'ACTIVE') {
+        if (!fiber.participants.includes(agent.address) && agent.state === AgentState.AGENT_STATE_ACTIVE) {
           return agent;
         }
       }

--- a/packages/traffic-generator/src/index.ts
+++ b/packages/traffic-generator/src/index.ts
@@ -24,7 +24,7 @@
 
 import 'dotenv/config';
 import type { GeneratorConfig, GenerationStats, Agent } from './types.js';
-import { DEFAULT_CONFIG } from './types.js';
+import { DEFAULT_CONFIG, SdkAgentState as AgentState } from './types.js';
 import { Simulator } from './simulator.js';
 import { HighThroughputSimulator, runHighThroughput } from './high-throughput.js';
 import { FiberOrchestrator, TrafficConfig } from './orchestrator.js';
@@ -168,7 +168,7 @@ async function runWeightedOrchestrator(): Promise<void> {
     address: w.address,
     privateKey: w.privateKey,
     fiberId: w.agentId ?? null,
-    state: w.agentId ? 'REGISTERED' : 'UNREGISTERED',
+    state: w.agentId ? AgentState.AGENT_STATE_REGISTERED : 'UNREGISTERED',
     fitness: { reputation: 0, completionRate: 0, networkEffect: 0, age: 0, total: 0 },
     meta: {
       birthGeneration: 0,

--- a/packages/traffic-generator/src/market-workflows.ts
+++ b/packages/traffic-generator/src/market-workflows.ts
@@ -9,7 +9,7 @@
  */
 
 import type { Market, MarketType, MarketState, SimulationContext, Agent } from './types.js';
-import { MarketState as MS } from './types.js';
+import { MarketState as MS, SdkAgentState as AgentState } from './types.js';
 
 // ============================================================================
 // Market State Machine Definition (mirrors JSON)
@@ -634,7 +634,7 @@ export function selectOracles(
   excludeAddress: string
 ): string[] {
   const eligible = population.filter(
-    a => a.state === 'ACTIVE' && 
+    a => a.state === AgentState.AGENT_STATE_ACTIVE && 
          a.address !== excludeAddress && 
          a.meta.isOracle
   );

--- a/packages/traffic-generator/src/selection.ts
+++ b/packages/traffic-generator/src/selection.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Agent, TransitionChoice, SimulationContext } from './types.js';
+import { SdkAgentState as AgentState } from './types.js';
 
 // ============================================================================
 // Fitness Computation
@@ -78,7 +79,7 @@ export function selectAgentByFitness(
   excludeAddresses: Set<string> = new Set()
 ): Agent | null {
   const eligible = population.filter(
-    (a) => a.state === 'ACTIVE' && !excludeAddresses.has(a.address)
+    (a) => a.state === AgentState.AGENT_STATE_ACTIVE && !excludeAddresses.has(a.address)
   );
   
   if (eligible.length === 0) return null;
@@ -134,7 +135,7 @@ export function selectCounterparty(
 ): Agent | null {
   const eligible = population.filter(
     (a) =>
-      a.state === 'ACTIVE' &&
+      a.state === AgentState.AGENT_STATE_ACTIVE &&
       a.address !== proposer.address &&
       !proposer.meta.activeContracts.has(a.address) // Not already in contract
   );
@@ -411,7 +412,7 @@ export function selectForDeath(
   population: Agent[],
   count: number
 ): Agent[] {
-  const eligible = population.filter((a) => a.state === 'ACTIVE');
+  const eligible = population.filter((a) => a.state === AgentState.AGENT_STATE_ACTIVE);
   if (eligible.length === 0) return [];
   
   // Invert fitness for death selection

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
   packages/bridge:
     dependencies:
       '@ottochain/sdk':
-        specifier: github:ottobot-ai/ottochain-sdk#309b6ec
-        version: https://codeload.github.com/ottobot-ai/ottochain-sdk/tar.gz/309b6ec(@stardust-collective/dag4@2.8.1)
+        specifier: github:ottobot-ai/ottochain-sdk#main
+        version: https://codeload.github.com/ottobot-ai/ottochain-sdk/tar.gz/02bdb59fc1fa91a525c1ba2f0b180ceb396cb0c3(@stardust-collective/dag4@2.8.1)
       '@ottochain/shared':
         specifier: workspace:*
         version: link:../shared
@@ -192,7 +192,7 @@ importers:
     dependencies:
       '@ottochain/sdk':
         specifier: github:ottobot-ai/ottochain-sdk#main
-        version: https://codeload.github.com/ottobot-ai/ottochain-sdk/tar.gz/2d5bfb52357803d85ddfe886e2c70f8b8eba38a9(@stardust-collective/dag4@2.8.1)
+        version: https://codeload.github.com/ottobot-ai/ottochain-sdk/tar.gz/02bdb59fc1fa91a525c1ba2f0b180ceb396cb0c3(@stardust-collective/dag4@2.8.1)
       '@prisma/client':
         specifier: ^5.9.0
         version: 5.22.0(prisma@5.22.0)
@@ -532,15 +532,8 @@ packages:
   '@noble/secp256k1@1.7.2':
     resolution: {integrity: sha512-/qzwYl5eFLH8OWIecQWM31qld2g1NfjgylK+TNhqtaUKP37Nm+Y+z30Fjhw0Ct8p9yCQEm2N3W/AckdIb3SMcQ==}
 
-  '@ottochain/sdk@https://codeload.github.com/ottobot-ai/ottochain-sdk/tar.gz/2d5bfb52357803d85ddfe886e2c70f8b8eba38a9':
-    resolution: {tarball: https://codeload.github.com/ottobot-ai/ottochain-sdk/tar.gz/2d5bfb52357803d85ddfe886e2c70f8b8eba38a9}
-    version: 0.1.0
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      '@stardust-collective/dag4': ^2.6.0
-
-  '@ottochain/sdk@https://codeload.github.com/ottobot-ai/ottochain-sdk/tar.gz/309b6ec':
-    resolution: {tarball: https://codeload.github.com/ottobot-ai/ottochain-sdk/tar.gz/309b6ec}
+  '@ottochain/sdk@https://codeload.github.com/ottobot-ai/ottochain-sdk/tar.gz/02bdb59fc1fa91a525c1ba2f0b180ceb396cb0c3':
+    resolution: {tarball: https://codeload.github.com/ottobot-ai/ottochain-sdk/tar.gz/02bdb59fc1fa91a525c1ba2f0b180ceb396cb0c3}
     version: 0.1.0
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -2294,21 +2287,7 @@ snapshots:
 
   '@noble/secp256k1@1.7.2': {}
 
-  '@ottochain/sdk@https://codeload.github.com/ottobot-ai/ottochain-sdk/tar.gz/2d5bfb52357803d85ddfe886e2c70f8b8eba38a9(@stardust-collective/dag4@2.8.1)':
-    dependencies:
-      '@bufbuild/protobuf': 2.11.0
-      '@stardust-collective/dag4': 2.8.1
-      '@stardust-collective/dag4-keystore': 2.8.1
-      canonicalize: 2.1.0
-      js-sha256: 0.11.1
-      js-sha512: 0.9.0
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@ottochain/sdk@https://codeload.github.com/ottobot-ai/ottochain-sdk/tar.gz/309b6ec(@stardust-collective/dag4@2.8.1)':
+  '@ottochain/sdk@https://codeload.github.com/ottobot-ai/ottochain-sdk/tar.gz/02bdb59fc1fa91a525c1ba2f0b180ceb396cb0c3(@stardust-collective/dag4@2.8.1)':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@stardust-collective/dag4': 2.8.1
@@ -2615,7 +2594,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.19.10
+      '@types/node': 20.19.33
 
   '@vitest/expect@4.0.18':
     dependencies:


### PR DESCRIPTION
Updates all enum references to use prefixed values after SDK PR #16:

### Changes
- `AgentState.ACTIVE` → `AgentState.AGENT_STATE_ACTIVE`
- `ContractState.PROPOSED` → `ContractState.CONTRACT_STATE_PROPOSED`
- `MarketState.OPEN` → `MarketState.MARKET_STATE_OPEN`
- `MarketType.PREDICTION` → `MarketType.MARKET_TYPE_PREDICTION`

### Removed
- Unused governance helper imports (`createMultisigState`, etc.) that were deleted in SDK #16

### Tested
- All packages build successfully with `@ottochain/sdk#main` (ts-proto)