### PR TITLE
fix(gateway): show all agents in leaderboard regardless of state

### DIFF
--- a/packages/gateway/src/resolvers.ts
+++ b/packages/gateway/src/resolvers.ts
@@ -90,8 +90,8 @@ export const resolvers = {
     },
 
     leaderboard: async (_: unknown, { limit = 10 }: { limit?: number }) => {
+      // Show top agents by reputation regardless of state (useful for testnet)
       return prisma.agent.findMany({
-        where: { state: 'ACTIVE' },
         orderBy: { reputation: 'desc' },
         take: limit,
       });


### PR DESCRIPTION
Previously leaderboard only returned ACTIVE agents, which made the dashboard's Top Agents section appear empty when all agents are still REGISTERED.

Now shows top agents by reputation regardless of state — more useful for testnet where agents may not transition to ACTIVE immediately.

**Change:** Removed `where: { state: 'ACTIVE' }` filter from leaderboard resolver.