### PR TITLE
feat(traffic-generator): add indexer verification for fiber transitions

### DIFF
--- a/packages/traffic-generator/README.md
+++ b/packages/traffic-generator/README.md
@@ -71,6 +71,28 @@ pnpm install
 | `PLATFORMS` | `discord,telegram,twitter,github` | Comma-separated platforms |
 | `SEED` | (random) | Seed for reproducible runs |
 
+#### Indexer Verification (Optional)
+
+When enabled, the traffic generator waits for each transition to be indexed before proceeding,
+and checks for ML0 rejections. This ensures the test accurately reflects on-chain state.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `INDEXER_VERIFY` | `false` | Enable indexer verification (`true` to enable) |
+| `INDEXER_URL` | `http://localhost:3031` | Indexer service URL (enables verification if set) |
+| `INDEXER_WAIT_TIMEOUT` | `30000` | Max ms to wait for indexer confirmation |
+| `INDEXER_POLL_INTERVAL` | `2000` | Poll interval when waiting for indexer |
+| `INDEXER_MAX_RETRIES` | `3` | Max retries on timeout before marking fiber as failed |
+| `INDEXER_SKIP_ON_REJECTION` | `true` | Remove fiber on rejection (vs keep trying) |
+
+**Example with indexer verification:**
+```bash
+INDEXER_URL=http://localhost:3031 \
+INDEXER_WAIT_TIMEOUT=60000 \
+BRIDGE_URL=http://localhost:3030 \
+pnpm dev -- --weighted
+```
+
 ### Running
 
 ```bash

--- a/packages/traffic-generator/src/indexer-client.ts
+++ b/packages/traffic-generator/src/indexer-client.ts
@@ -1,0 +1,273 @@
+/**
+ * Indexer Client
+ * 
+ * HTTP client for querying the OttoChain indexer to verify transaction processing
+ * and check for rejections before proceeding with next transitions.
+ */
+
+export interface IndexerConfig {
+  indexerUrl: string;
+  timeoutMs?: number;
+}
+
+export interface IndexerStatus {
+  lastIndexedOrdinal: number | null;
+  lastConfirmedOrdinal: number | null;
+  totalFibers: number;
+  totalRejections: number;
+}
+
+export interface IndexedFiber {
+  fiberId: string;
+  workflowType: string;
+  currentState: string;
+  status: 'ACTIVE' | 'ARCHIVED' | 'FAILED';
+  sequenceNumber: number;
+  updatedOrdinal: number;
+  updatedGl0Ordinal: number | null;
+}
+
+export interface FiberTransition {
+  id: number;
+  fiberId: string;
+  eventName: string;
+  fromState: string;
+  toState: string;
+  success: boolean;
+  snapshotOrdinal: number;
+  gl0Ordinal: number | null;
+  createdAt: string;
+}
+
+export interface RejectedTransaction {
+  id: number;
+  ordinal: number;
+  timestamp: string;
+  updateType: string;
+  fiberId: string;
+  updateHash: string;
+  errors: Array<{ code: string; message: string }>;
+  signers: string[];
+  createdAt: string;
+}
+
+export interface FiberVerification {
+  found: boolean;
+  fiber: IndexedFiber | null;
+  lastTransition: FiberTransition | null;
+  rejections: RejectedTransaction[];
+  hasUnprocessedRejection: boolean;
+}
+
+export class IndexerClient {
+  private baseUrl: string;
+  private timeout: number;
+
+  constructor(config: IndexerConfig) {
+    this.baseUrl = config.indexerUrl.replace(/\/$/, '');
+    this.timeout = config.timeoutMs ?? 10000;
+  }
+
+  // ==========================================================================
+  // Status
+  // ==========================================================================
+
+  async getStatus(): Promise<IndexerStatus> {
+    const res = await this.get<IndexerStatus>('/status');
+    return res;
+  }
+
+  async isHealthy(): Promise<boolean> {
+    try {
+      const res = await fetch(`${this.baseUrl}/health`, {
+        signal: AbortSignal.timeout(5000)
+      });
+      const data = await res.json() as { status: string };
+      return data.status === 'ok';
+    } catch {
+      return false;
+    }
+  }
+
+  // ==========================================================================
+  // Fiber Queries
+  // ==========================================================================
+
+  async getFiber(fiberId: string): Promise<IndexedFiber | null> {
+    try {
+      const res = await this.get<IndexedFiber>(`/fibers/${fiberId}`);
+      return res;
+    } catch (err) {
+      if ((err as Error).message.includes('404')) {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  async getFiberTransitions(fiberId: string, limit: number = 10): Promise<FiberTransition[]> {
+    try {
+      const res = await this.get<{ transitions: FiberTransition[] }>(
+        `/fibers/${fiberId}/transitions?limit=${limit}`
+      );
+      return res.transitions ?? [];
+    } catch {
+      return [];
+    }
+  }
+
+  // ==========================================================================
+  // Rejection Queries
+  // ==========================================================================
+
+  async getFiberRejections(fiberId: string, limit: number = 10): Promise<RejectedTransaction[]> {
+    try {
+      const res = await this.get<{ rejections: RejectedTransaction[] }>(
+        `/fibers/${fiberId}/rejections?limit=${limit}`
+      );
+      return res.rejections ?? [];
+    } catch {
+      return [];
+    }
+  }
+
+  async hasRecentRejection(fiberId: string, sinceOrdinal?: number): Promise<boolean> {
+    const rejections = await this.getFiberRejections(fiberId, 5);
+    if (rejections.length === 0) return false;
+    
+    if (sinceOrdinal !== undefined) {
+      return rejections.some(r => r.ordinal >= sinceOrdinal);
+    }
+    return true;
+  }
+
+  // ==========================================================================
+  // Verification (Combined Queries)
+  // ==========================================================================
+
+  /**
+   * Verify a fiber's state in the indexer
+   * Returns comprehensive status including last transition and any rejections
+   */
+  async verifyFiber(fiberId: string): Promise<FiberVerification> {
+    const [fiber, transitions, rejections] = await Promise.all([
+      this.getFiber(fiberId),
+      this.getFiberTransitions(fiberId, 1),
+      this.getFiberRejections(fiberId, 5),
+    ]);
+
+    // Check if there are rejections newer than the last successful transition
+    const lastTransition = transitions[0] ?? null;
+    const lastTransitionOrdinal = lastTransition?.snapshotOrdinal ?? 0;
+    const hasUnprocessedRejection = rejections.some(r => r.ordinal > lastTransitionOrdinal);
+
+    return {
+      found: fiber !== null,
+      fiber,
+      lastTransition,
+      rejections,
+      hasUnprocessedRejection,
+    };
+  }
+
+  /**
+   * Wait for a fiber to appear in the indexer
+   * Polls until found or timeout
+   */
+  async waitForFiber(
+    fiberId: string,
+    options: { timeoutMs?: number; pollIntervalMs?: number } = {}
+  ): Promise<{ found: boolean; fiber: IndexedFiber | null }> {
+    const timeout = options.timeoutMs ?? 30000;
+    const pollInterval = options.pollIntervalMs ?? 2000;
+    const deadline = Date.now() + timeout;
+
+    while (Date.now() < deadline) {
+      const fiber = await this.getFiber(fiberId);
+      if (fiber) {
+        return { found: true, fiber };
+      }
+      await this.sleep(pollInterval);
+    }
+
+    return { found: false, fiber: null };
+  }
+
+  /**
+   * Wait for a fiber to reach a specific state in the indexer
+   */
+  async waitForState(
+    fiberId: string,
+    expectedState: string,
+    options: { timeoutMs?: number; pollIntervalMs?: number } = {}
+  ): Promise<{ found: boolean; fiber: IndexedFiber | null; actualState: string | null }> {
+    const timeout = options.timeoutMs ?? 30000;
+    const pollInterval = options.pollIntervalMs ?? 2000;
+    const deadline = Date.now() + timeout;
+
+    while (Date.now() < deadline) {
+      const fiber = await this.getFiber(fiberId);
+      if (fiber) {
+        if (fiber.currentState === expectedState) {
+          return { found: true, fiber, actualState: fiber.currentState };
+        }
+        // Found but wrong state - keep polling
+      }
+      await this.sleep(pollInterval);
+    }
+
+    // Final check
+    const fiber = await this.getFiber(fiberId);
+    return { 
+      found: fiber?.currentState === expectedState, 
+      fiber, 
+      actualState: fiber?.currentState ?? null 
+    };
+  }
+
+  /**
+   * Wait for indexer to process up to a specific ML0 ordinal
+   */
+  async waitForOrdinal(
+    targetOrdinal: number,
+    options: { timeoutMs?: number; pollIntervalMs?: number } = {}
+  ): Promise<{ reached: boolean; currentOrdinal: number | null }> {
+    const timeout = options.timeoutMs ?? 60000;
+    const pollInterval = options.pollIntervalMs ?? 3000;
+    const deadline = Date.now() + timeout;
+
+    while (Date.now() < deadline) {
+      const status = await this.getStatus();
+      if (status.lastIndexedOrdinal !== null && status.lastIndexedOrdinal >= targetOrdinal) {
+        return { reached: true, currentOrdinal: status.lastIndexedOrdinal };
+      }
+      await this.sleep(pollInterval);
+    }
+
+    const status = await this.getStatus();
+    return { reached: false, currentOrdinal: status.lastIndexedOrdinal };
+  }
+
+  // ==========================================================================
+  // Internal Helpers
+  // ==========================================================================
+
+  private async get<T>(path: string): Promise<T> {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method: 'GET',
+      headers: { 'Accept': 'application/json' },
+      signal: AbortSignal.timeout(this.timeout),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => 'Unknown error');
+      throw new Error(`Indexer GET ${path} failed (${res.status}): ${text}`);
+    }
+
+    return res.json() as Promise<T>;
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+}


### PR DESCRIPTION
## Summary

Adds optional integration between traffic generator and indexer to ensure transitions are properly indexed before proceeding.

## Problem

The traffic generator was driving fibers forward without waiting for the indexer to process previous transitions. This caused:
- Race conditions where next transition ran before previous was indexed
- No detection of ML0 rejections
- Integration tests that didn't verify indexer state

## Solution

### New Components

**IndexerClient** (`indexer-client.ts`)
- HTTP client for querying indexer fiber/rejection status
- `verifyFiber()`: Get comprehensive status including rejections
- `waitForFiber()`: Poll until fiber appears in indexer
- `waitForState()`: Poll until fiber reaches expected state

**TrafficConfig.indexer**
- Configuration block for verification settings
- `enabled`: Toggle verification on/off
- `url`: Indexer service URL
- `waitTimeoutMs`: Max wait time per transition
- `maxRetries`: Retries before marking failed

**ActiveFiber.pendingTransition**
- Track transitions awaiting indexer confirmation
- Includes expected state, submitted timestamp, retry count

### New Indexer Endpoints

- `GET /fibers/:fiberId` - Get fiber state
- `GET /fibers/:fiberId/transitions` - Get transition history

### Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `INDEXER_URL` | - | Indexer URL (enables verification) |
| `INDEXER_VERIFY` | `false` | Explicit enable flag |
| `INDEXER_WAIT_TIMEOUT` | `30000` | Max ms to wait |
| `INDEXER_POLL_INTERVAL` | `2000` | Poll interval |
| `INDEXER_MAX_RETRIES` | `3` | Retries before failed |

## Testing

Integration test updated to optionally verify indexer state when `INDEXER_URL` is provided.

## Usage

```bash
# Enable indexer verification
INDEXER_URL=http://localhost:3031 \
BRIDGE_URL=http://localhost:3030 \
pnpm dev -- --weighted
```

Output now shows rejected/pending counts:
```
Generation 5:
  Active: 20 | Created: 2 | Driven: 8 | Completed: 1
  Rejected: 0 | Pending: 3 | Total Failed: 0
```
