### PR TITLE
fix: add INDEXER_URL to integration test + check rejections

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -257,9 +257,11 @@ jobs:
         env:
           BRIDGE_URL: http://localhost:3030
           ML0_URL: http://localhost:9200
+          INDEXER_URL: http://localhost:3031
           FIBER_WAIT_TIMEOUT: '60'
           DL1_SYNC_WAIT: '15'
           ACTIVATION_WAIT: '10'
+          INDEXER_WAIT_TIMEOUT: '30000'
           MAX_RETRIES: '3'
         run: |
           # Retry logic for flaky metagraph consensus timing


### PR DESCRIPTION
Fixes flaky integration test by:

1. **Setting INDEXER_URL** in traffic generator test step (was missing)
2. **Checking for rejections** while waiting for fiber to appear
3. **Failing fast** if transaction was rejected (no point retrying)

Now if a transaction is rejected, we'll see the actual error instead of timing out after 60s.