### PR TITLE
fix: copy Prisma schema before pnpm install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ COPY packages/monitor/package.json ./packages/monitor/
 COPY packages/traffic-generator/package.json ./packages/traffic-generator/
 COPY packages/shared/package.json ./packages/shared/
 
+# Copy Prisma schema (needed for postinstall hook)
+COPY prisma ./prisma/
+
 # Install dependencies
 RUN pnpm install --frozen-lockfile
 


### PR DESCRIPTION
The postinstall hook runs `prisma generate` which requires the schema to be present.

This was causing Docker builds to fail with:
```
Could not find Prisma Schema that is required for this command
```