### PR TITLE
fix(ci): move secrets check inside run script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,13 +105,17 @@ jobs:
           generate_release_notes: true
 
       - name: Notify deploy repo
-        if: secrets.DEPLOY_REPO_TOKEN != ''
         env:
-          GH_TOKEN: ${{ secrets.DEPLOY_REPO_TOKEN }}
+          DEPLOY_TOKEN: ${{ secrets.DEPLOY_REPO_TOKEN }}
         run: |
+          if [ -z "$DEPLOY_TOKEN" ]; then
+            echo "⚠️ DEPLOY_REPO_TOKEN not set, skipping deploy notification"
+            exit 0
+          fi
           gh api repos/ottobot-ai/ottochain-deploy/dispatches \
             -f event_type=version-bump \
-            -f 'client_payload={"component":"services","version":"${{ steps.version.outputs.version }}"}'
+            -f 'client_payload={"component":"services","version":"${{ steps.version.outputs.version }}"}' \
+            --header "Authorization: token $DEPLOY_TOKEN"
           echo "✅ Notified deploy repo to bump services to v${{ steps.version.outputs.version }}"
 
       - name: Summary


### PR DESCRIPTION
GitHub Actions doesn't allow `secrets.*` in `if` conditions - causes workflow validation failure.

Same fix as scasplte2/ottochain#48.