### PR TITLE
fix: add Prisma binaryTarget for Debian Bookworm (OpenSSL 3.0)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,7 @@
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  // node:20-slim uses Debian Bookworm with OpenSSL 3.0
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Issue
Gateway and bridge containers crash on startup with:
```
Error loading shared library libssl.so.1.1: No such file or directory
```

## Root Cause
- `node:20-slim` uses Debian Bookworm which ships OpenSSL 3.x
- Prisma's default query engine binary expects OpenSSL 1.1
- The library path `libssl.so.1.1` doesn't exist in OpenSSL 3

## Fix
Add `binaryTargets = ["native", "debian-openssl-3.0.x"]` to Prisma schema.
This generates the correct query engine for Debian Bookworm.

## Testing
After merge + release, redeploy services to verify containers start properly.