### PR TITLE
fix: use RELEASE_TOKEN for release-please to trigger CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           release-type: node
           package-name: "ottochain-services"
+          # Use PAT so PR commits trigger CI workflows (GITHUB_TOKEN doesn't)
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Summary
         if: steps.release.outputs.release_created == 'true'


### PR DESCRIPTION
## Issue
Release-please PRs don't trigger integration tests because `GITHUB_TOKEN` commits don't trigger other workflows (GitHub's anti-recursion protection).

## Fix
Use `RELEASE_TOKEN` (PAT) instead, which will trigger CI on release-please PR commits.

## Required
⚠️ **Add `RELEASE_TOKEN` secret** to this repo (same PAT used in ottochain main repo).

Settings → Secrets → Actions → New repository secret