### PR TITLE
fix: use GH_TOKEN env var for gh api command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,10 +106,10 @@ jobs:
 
       - name: Notify deploy repo
         env:
-          GH_TOKEN: ${{ secrets.DEPLOY_REPO_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "⚠️ DEPLOY_REPO_TOKEN not set, skipping deploy notification"
+            echo "⚠️ RELEASE_TOKEN not set, skipping deploy notification"
             exit 0
           fi
           gh api repos/ottobot-ai/ottochain-deploy/dispatches \


### PR DESCRIPTION
## Problem
gh api requires GH_TOKEN environment variable to authenticate.

## Fix
- Use GH_TOKEN env var instead of custom header
- Consolidated to use `RELEASE_TOKEN` (same as PR #76) — one secret for everything

Fixes #77