### PR TITLE
refactor: use indexer as source of truth for state verification

### DIFF
--- a/packages/traffic-generator/src/types.ts
+++ b/packages/traffic-generator/src/types.ts
@@ -342,6 +342,8 @@ export interface GeneratorConfig {
   bridgeUrl: string;
   /** ML0 URL for state queries */
   ml0Url: string;
+  /** Indexer URL for state verification (preferred over ML0) */
+  indexerUrl: string;
   /** Platform names for agent distribution */
   platforms: string[];
   /** Seed for reproducible runs (optional) */
@@ -373,6 +375,7 @@ export const DEFAULT_CONFIG: GeneratorConfig = {
   maxGenerations: 0, // Infinite
   bridgeUrl: 'http://localhost:3030',
   ml0Url: 'http://localhost:9200',
+  indexerUrl: 'http://localhost:3031',
   platforms: ['discord', 'telegram', 'twitter', 'github'],
   seed: undefined,
   // Market defaults


### PR DESCRIPTION
## Summary

Uses the Indexer as the source of truth for verifying fiber state, instead of polling the ML0 checkpoint directly.

## Changes

- **types.ts**: Added indexerUrl to GeneratorConfig and DEFAULT_CONFIG
- **simulator.ts**: 
  - Added IndexerClient dependency
  - Replaced ML0 checkpoint polling with indexer.waitForFiber()
  - Auto-detects rejections for faster failure reporting
- **integration.test.ts**:
  - Rewritten to use IndexerClient for state verification
  - Simplified from 246 lines of manual polling to clean client calls
  - Better rejection reporting via indexer.verifyFiber()

## Benefits

1. Direct lookup: Query by fiberId instead of parsing giant checkpoint JSON
2. Built-in rejection tracking: Indexer already receives rejection webhooks from ML0
3. Single source of truth: Indexer gets pushed state from ML0, so it's authoritative
4. Cleaner code: Reuses existing IndexerClient instead of inline fetch logic
5. Consistent pattern: Works the same for all workflow types (agents, contracts, markets)

## Testing

Build passes. Needs integration test to verify (which is what this PR aims to fix).
