### PR TITLE
fix: copy prisma schema to production Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY packages/monitor/package.json ./packages/monitor/
 COPY packages/traffic-generator/package.json ./packages/traffic-generator/
 COPY packages/shared/package.json ./packages/shared/
 
-# Copy Prisma schema (needed for postinstall hook)
+# Copy Prisma schema (needed for prisma generate)
 COPY prisma ./prisma/
 
 # Install dependencies
@@ -53,6 +53,9 @@ RUN corepack enable && corepack prepare pnpm@8 --activate
 COPY --from=builder /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml ./
 COPY --from=builder /app/packages ./packages
 COPY --from=builder /app/node_modules ./node_modules
+
+# Copy Prisma schema (needed for runtime migrations via prisma db push)
+COPY --from=builder /app/prisma ./prisma
 
 # Copy entrypoint script
 COPY docker-entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
## Problem
Services deployment fails with:
```
Error: Could not find Prisma Schema that is required for this command.
```

## Root Cause
The `prisma/` directory was copied during the build stage (for client generation) but not included in the final production image.

## Fix
Add missing COPY instruction:
```dockerfile
COPY --from=builder /app/prisma ./prisma
```

## Testing
After this fix, `docker exec indexer npx prisma db push` should find the schema at `/app/prisma/schema.prisma`.