### PR TITLE
fix(ci): use correct database in postgres health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U ottochain -d ottochain_identity"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,7 +27,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U ottochain"
+          --health-cmd "pg_isready -U ottochain -d ottochain_identity"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5


### PR DESCRIPTION
## Problem
The CI integration test was failing with repeated `FATAL: database "ottochain" does not exist` errors for 11+ minutes.

## Root Cause
The `pg_isready` health check without `-d` flag defaults to database name = username. Since:
- `POSTGRES_USER=ottochain`
- `POSTGRES_DB=ottochain_identity`

The health check was trying to connect to database `ottochain` instead of `ottochain_identity`.

## Fix
Add `-d ottochain_identity` to the health check command in both CI workflows.

## Testing
- Should resolve: https://github.com/ottobot-ai/ottochain-services/actions/runs/21974292253/job/63484761618