### PR TITLE
refactor(db): rename database from ottochain_identity to ottochain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,11 @@ jobs:
         env:
           POSTGRES_USER: ottochain
           POSTGRES_PASSWORD: ottochain
-          POSTGRES_DB: ottochain_identity
+          POSTGRES_DB: ottochain
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U ottochain -d ottochain_identity"
+          --health-cmd "pg_isready -U ottochain -d ottochain"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -93,7 +93,7 @@ jobs:
       
       - name: Validate schema
         env:
-          DATABASE_URL: postgresql://ottochain:ottochain@localhost:5432/ottochain_identity
+          DATABASE_URL: postgresql://ottochain:ottochain@localhost:5432/ottochain
         run: |
           pnpm db:push --skip-generate
           pnpm db:generate

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,11 +23,11 @@ jobs:
         env:
           POSTGRES_USER: ottochain
           POSTGRES_PASSWORD: ottochain
-          POSTGRES_DB: ottochain_identity
+          POSTGRES_DB: ottochain
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U ottochain -d ottochain_identity"
+          --health-cmd "pg_isready -U ottochain -d ottochain"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -89,7 +89,7 @@ jobs:
 
       - name: Push database schema
         env:
-          DATABASE_URL: postgresql://ottochain:ottochain@localhost:5432/ottochain_identity
+          DATABASE_URL: postgresql://ottochain:ottochain@localhost:5432/ottochain
         run: pnpm db:push --skip-generate
 
       - name: Cache tessellation assemblies

--- a/docker-compose.ci.yaml
+++ b/docker-compose.ci.yaml
@@ -19,7 +19,7 @@ services:
       - SERVICE=indexer
       - NODE_ENV=test
       # Connect to postgres on host via host.docker.internal
-      - DATABASE_URL=postgresql://ottochain:ottochain@host.docker.internal:5432/ottochain_identity
+      - DATABASE_URL=postgresql://ottochain:ottochain@host.docker.internal:5432/ottochain
       # Connect to metagraph via container names on tessellation_common
       - METAGRAPH_ML0_URL=http://ml0-0:9200
       - METAGRAPH_DL1_URL=http://dl1-0:9400
@@ -48,7 +48,7 @@ services:
       - SERVICE=bridge
       - NODE_ENV=test
       # Connect to postgres on host via host.docker.internal
-      - DATABASE_URL=postgresql://ottochain:ottochain@host.docker.internal:5432/ottochain_identity
+      - DATABASE_URL=postgresql://ottochain:ottochain@host.docker.internal:5432/ottochain
       # Connect to metagraph via container names on tessellation_common
       - METAGRAPH_ML0_URL=http://ml0-0:9200
       - METAGRAPH_DL1_URL=http://dl1-0:9400

--- a/docker-compose.legacy.yml
+++ b/docker-compose.legacy.yml
@@ -11,7 +11,7 @@ services:
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-ottochain}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
-      POSTGRES_DB: ${POSTGRES_DB:-ottochain_identity}
+      POSTGRES_DB: ${POSTGRES_DB:-ottochain}
     ports:
       - "5432:5432"
     volumes:
@@ -30,7 +30,7 @@ services:
     ports:
       - "4000:4000"
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-ottochain}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ottochain_identity}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-ottochain}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ottochain}
       METAGRAPH_ML0_URL: http://host.docker.internal:9100
       METAGRAPH_DL1_URL: http://host.docker.internal:9400
       GATEWAY_PORT: 4000
@@ -46,7 +46,7 @@ services:
     ports:
       - "3030:3030"
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-ottochain}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ottochain_identity}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-ottochain}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ottochain}
       METAGRAPH_ML0_URL: http://host.docker.internal:9100
       METAGRAPH_DL1_URL: http://host.docker.internal:9400
       BRIDGE_PORT: 3030
@@ -62,7 +62,7 @@ services:
     ports:
       - "3031:3031"
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-ottochain}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ottochain_identity}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-ottochain}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ottochain}
       METAGRAPH_ML0_URL: http://host.docker.internal:9100
       METAGRAPH_DL1_URL: http://host.docker.internal:9400
       INDEXER_PORT: 3031

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -7,7 +7,7 @@ services:
       - "4000:4000"
     environment:
       SERVICE: gateway
-      DATABASE_URL: postgresql://ottochain:ottochain@postgres:5432/ottochain_identity
+      DATABASE_URL: postgresql://ottochain:ottochain@postgres:5432/ottochain
       METAGRAPH_ML0_URL: http://host.docker.internal:9200
       METAGRAPH_DL1_URL: http://host.docker.internal:9400
       GATEWAY_PORT: 4000
@@ -27,7 +27,7 @@ services:
       - "3030:3030"
     environment:
       SERVICE: bridge
-      DATABASE_URL: postgresql://ottochain:ottochain@postgres:5432/ottochain_identity
+      DATABASE_URL: postgresql://ottochain:ottochain@postgres:5432/ottochain
       METAGRAPH_ML0_URL: http://host.docker.internal:9200
       METAGRAPH_DL1_URL: http://host.docker.internal:9400
       BRIDGE_PORT: 3030
@@ -47,7 +47,7 @@ services:
       - "3031:3031"
     environment:
       SERVICE: indexer
-      DATABASE_URL: postgresql://ottochain:ottochain@postgres:5432/ottochain_identity
+      DATABASE_URL: postgresql://ottochain:ottochain@postgres:5432/ottochain
       METAGRAPH_ML0_URL: http://host.docker.internal:9200
       METAGRAPH_DL1_URL: http://host.docker.internal:9400
       INDEXER_PORT: 3031
@@ -71,7 +71,7 @@ services:
     environment:
       POSTGRES_USER: ottochain
       POSTGRES_PASSWORD: ottochain
-      POSTGRES_DB: ottochain_identity
+      POSTGRES_DB: ottochain
     ports:
       - "5432:5432"
     volumes:

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -85,7 +85,7 @@ for i in {1..30}; do
 done
 
 log "Pushing database schema..."
-DATABASE_URL="postgresql://ottochain:ottochain@localhost:$POSTGRES_PORT/ottochain_identity" \
+DATABASE_URL="postgresql://ottochain:ottochain@localhost:$POSTGRES_PORT/ottochain" \
     pnpm db:push --skip-generate 2>/dev/null
 
 log "Starting metagraph cluster..."
@@ -123,7 +123,7 @@ cd "$SERVICES_DIR"
 pnpm build >/dev/null 2>&1
 
 log "Starting indexer..."
-DATABASE_URL="postgresql://ottochain:ottochain@localhost:$POSTGRES_PORT/ottochain_identity" \
+DATABASE_URL="postgresql://ottochain:ottochain@localhost:$POSTGRES_PORT/ottochain" \
 METAGRAPH_ML0_URL="http://localhost:$ML0_PORT" \
 METAGRAPH_DL1_URL="http://localhost:$DL1_PORT" \
 INDEXER_PORT=$INDEXER_PORT \
@@ -210,7 +210,7 @@ log "  ✅ Indexer processed ordinal $INDEXED_ORDINAL"
 
 log "TEST 3: PostgreSQL persistence"
 
-SNAPSHOT_COUNT=$(docker compose exec -T postgres psql -U ottochain -d ottochain_identity -t -c \
+SNAPSHOT_COUNT=$(docker compose exec -T postgres psql -U ottochain -d ottochain -t -c \
     "SELECT COUNT(*) FROM \"IndexedSnapshot\";" 2>/dev/null | tr -d ' ')
 
 if [ "$SNAPSHOT_COUNT" -lt 1 ]; then

--- a/scripts/start-local-stack.sh
+++ b/scripts/start-local-stack.sh
@@ -53,7 +53,7 @@ for i in {1..30}; do
 done
 
 # Push schema
-DATABASE_URL="postgresql://ottochain:ottochain@localhost:5432/ottochain_identity" \
+DATABASE_URL="postgresql://ottochain:ottochain@localhost:5432/ottochain" \
     pnpm db:push --skip-generate 2>/dev/null
 log "  ✓ Schema pushed"
 
@@ -102,7 +102,7 @@ fi
 
 # Start Indexer
 log "  Starting Indexer (port 3031)..."
-DATABASE_URL="postgresql://ottochain:ottochain@localhost:5432/ottochain_identity" \
+DATABASE_URL="postgresql://ottochain:ottochain@localhost:5432/ottochain" \
 METAGRAPH_ML0_URL="http://localhost:9200" \
 METAGRAPH_DL1_URL="http://localhost:9400" \
 INDEXER_PORT=3031 \
@@ -119,7 +119,7 @@ fi
 
 # Start Gateway
 log "  Starting Gateway (port 4000)..."
-DATABASE_URL="postgresql://ottochain:ottochain@localhost:5432/ottochain_identity" \
+DATABASE_URL="postgresql://ottochain:ottochain@localhost:5432/ottochain" \
 METAGRAPH_ML0_URL="http://localhost:9200" \
 GATEWAY_PORT=4000 \
     node packages/gateway/dist/index.js > /tmp/gateway.log 2>&1 &
@@ -136,7 +136,7 @@ fi
 
 # Start Bridge
 log "  Starting Bridge (port 3030)..."
-DATABASE_URL="postgresql://ottochain:ottochain@localhost:5432/ottochain_identity" \
+DATABASE_URL="postgresql://ottochain:ottochain@localhost:5432/ottochain" \
 METAGRAPH_ML0_URL="http://localhost:9200" \
 METAGRAPH_DL1_URL="http://localhost:9400" \
 BRIDGE_PORT=3030 \


### PR DESCRIPTION
## Summary
The services database supports more than just identity now — markets, governance, scripts, etc. Simplify the name to match the broader scope.

## Changes
- `.github/workflows/ci.yml` — POSTGRES_DB and health check
- `.github/workflows/integration.yml` — POSTGRES_DB, health check, DATABASE_URLs
- `docker-compose.local.yml` — All DATABASE_URL and POSTGRES_DB refs
- `docker-compose.legacy.yml` — Same
- `scripts/integration-test.sh` — DATABASE_URL and psql commands
- `scripts/start-local-stack.sh` — DATABASE_URL refs

## Deploy Note
Existing deployments using `ottochain_identity` will need their .env updated or a database rename/migration.