### PR TITLE
fix(ci): free disk space before integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,6 +33,18 @@ jobs:
           --health-retries 5
 
     steps:
+      - name: Free disk space
+        run: |
+          # Remove unnecessary tools to free ~6-10GB
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          # Clean Docker
+          docker system prune -af --volumes || true
+          # Show available space
+          df -h /
+
       - name: Checkout ottochain-services
         uses: actions/checkout@v4
 
@@ -128,6 +140,15 @@ jobs:
         working-directory: ottochain
         run: |
           sbt "currencyL0/assembly; dataL1/assembly"
+
+      - name: Clean up build artifacts
+        run: |
+          # Remove sbt intermediate files to free disk space
+          # Keep only the final assembly JARs (cached separately)
+          find tessellation/modules -name "*.class" -delete 2>/dev/null || true
+          find ottochain/modules -name "*.class" -delete 2>/dev/null || true
+          rm -rf ~/.sbt/boot ~/.ivy2/cache 2>/dev/null || true
+          df -h /
 
       - name: Verify test keys exist and are different
         working-directory: tessellation/docker


### PR DESCRIPTION
## Problem
GitHub runners only have ~14GB disk. Our integration tests build:
- Tessellation: 6+ fat JARs (~1.5GB in target/)
- OttoChain: 2 fat JARs
- Docker images: tessellation + services
- Plus all the sbt intermediate files

This caused a disk space failure: https://github.com/ottobot-ai/ottochain-services/actions/runs/21993715873

## Solution
1. **Free disk at start** — Remove unused pre-installed tools (~6-10GB):
   - `/usr/share/dotnet` (~2GB)
   - `/usr/local/lib/android` (~5GB)
   - `/opt/ghc` (~2GB)
   - `/opt/hostedtoolcache/CodeQL` (~1GB)
2. **Clean Docker** — `docker system prune` before we start building
3. **Clean after builds** — Remove .class files after sbt (JARs are cached)
4. **Add checkpoints** — `df -h` to monitor space usage

## Notes
The cache still works — we only delete intermediate files that aren't needed after assembly JARs are built.