### PR TITLE
fix(monitor): add plural node URL env vars for health checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,10 @@ INDEXER_PORT=3031
 TRAFFIC_AGENT_COUNT=50
 TRAFFIC_TPS=2
 TRAFFIC_WORKFLOW_WEIGHTS=identity:30,token:25,fiber:20,marketplace:15,market:10
+
+# Monitor node URLs (plural format for multi-node clusters)
+# Falls back to singular GL0_URL etc if not set
+GL0_URLS=http://localhost:9000
+ML0_URLS=http://localhost:9200
+CL1_URLS=http://localhost:9300
+DL1_URLS=http://localhost:9400

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,12 @@ services:
       - DATABASE_URL=${DATABASE_URL}
       - METAGRAPH_ML0_URL=${METAGRAPH_ML0_URL}
       - METAGRAPH_DL1_URL=${METAGRAPH_DL1_URL}
+      - GL0_URL=${GL0_URL}
+      - GL0_URLS=${GL0_URLS:-${GL0_URL}}
+      - ML0_URLS=${ML0_URLS:-${ML0_URL}}
+      - CL1_URLS=${CL1_URLS:-${CL1_URL}}
+      - DL1_URLS=${DL1_URLS:-${DL1_URL}}
+      - METAGRAPH_ID=${METAGRAPH_ID}
       - REDIS_URL=${REDIS_URL:-redis://redis:6379}
     depends_on:
       - redis
@@ -46,6 +52,12 @@ services:
       - DATABASE_URL=${DATABASE_URL}
       - METAGRAPH_ML0_URL=${METAGRAPH_ML0_URL}
       - METAGRAPH_DL1_URL=${METAGRAPH_DL1_URL}
+      - GL0_URL=${GL0_URL}
+      - GL0_URLS=${GL0_URLS:-${GL0_URL}}
+      - ML0_URLS=${ML0_URLS:-${ML0_URL}}
+      - CL1_URLS=${CL1_URLS:-${CL1_URL}}
+      - DL1_URLS=${DL1_URLS:-${DL1_URL}}
+      - METAGRAPH_ID=${METAGRAPH_ID}
       - REDIS_URL=${REDIS_URL:-redis://redis:6379}
     depends_on:
       - redis
@@ -69,6 +81,12 @@ services:
       - DATABASE_URL=${DATABASE_URL}
       - METAGRAPH_ML0_URL=${METAGRAPH_ML0_URL}
       - METAGRAPH_DL1_URL=${METAGRAPH_DL1_URL}
+      - GL0_URL=${GL0_URL}
+      - GL0_URLS=${GL0_URLS:-${GL0_URL}}
+      - ML0_URLS=${ML0_URLS:-${ML0_URL}}
+      - CL1_URLS=${CL1_URLS:-${CL1_URL}}
+      - DL1_URLS=${DL1_URLS:-${DL1_URL}}
+      - METAGRAPH_ID=${METAGRAPH_ID}
       - INDEXER_PORT=3031
       - INDEXER_CALLBACK_URL=${INDEXER_CALLBACK_URL:-http://indexer:3031/webhook/snapshot}
     depends_on:
@@ -93,6 +111,12 @@ services:
       - DATABASE_URL=${DATABASE_URL}
       - METAGRAPH_ML0_URL=${METAGRAPH_ML0_URL}
       - METAGRAPH_DL1_URL=${METAGRAPH_DL1_URL}
+      - GL0_URL=${GL0_URL}
+      - GL0_URLS=${GL0_URLS:-${GL0_URL}}
+      - ML0_URLS=${ML0_URLS:-${ML0_URL}}
+      - CL1_URLS=${CL1_URLS:-${CL1_URL}}
+      - DL1_URLS=${DL1_URLS:-${DL1_URL}}
+      - METAGRAPH_ID=${METAGRAPH_ID}
       - REDIS_URL=${REDIS_URL:-redis://redis:6379}
     depends_on:
       - redis


### PR DESCRIPTION
## Problem
The monitor service was reporting `Nodes: 0/5` even when all nodes were reachable and healthy.

## Root Cause
The monitor code expects `GL0_URLS`, `ML0_URLS`, `CL1_URLS`, `DL1_URLS` (plural, comma-separated format) but docker-compose.yml only passed the singular versions (`GL0_URL`, etc).

## Solution
- Add the plural URL vars to the monitor service in docker-compose.yml
- Use fallback syntax: `${GL0_URLS:-${GL0_URL}}` for backward compatibility  
- Document new vars in .env.example

## Testing
Verified on scratch cluster:
- Before: `❌ Nodes: 0/5`
- After: `⚠️ Nodes: 4/4 | Ordinal: 595`

## Related
Part of cluster stability investigation - monitor now correctly tracks node health for alerting.