### PR TITLE
fix(monitor): disable basic auth by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,7 @@ services:
       - "3032:3032"
     environment:
       - SERVICE=monitor
+      - MONITOR_AUTH=false
       - NODE_ENV=production
       - DATABASE_URL=${DATABASE_URL}
       - METAGRAPH_ML0_URL=${METAGRAPH_ML0_URL}


### PR DESCRIPTION
The status page at status.ottochain.ai should be publicly accessible without requiring authentication.

Adds `MONITOR_AUTH=false` to docker-compose.yml for the monitor service.