### PR TITLE
fix(bridge): wait for DL1 sequence increment after each market transition (#109)

### DIFF
--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -11,6 +11,7 @@
     "test": "node --test --experimental-strip-types test/*.test.ts",
     "test:e2e": "node --test --experimental-strip-types test/e2e.test.ts",
     "test:lifecycle": "node --test --experimental-strip-types test/lifecycle.test.ts",
+    "test:sequence": "node --test --experimental-strip-types test/market-sequence.test.ts",
     "test:coverage": "mkdir -p coverage && node --test --experimental-strip-types --experimental-test-coverage --test-reporter lcov --test-reporter-destination coverage/lcov.info test/*.test.ts || true"
   },
   "dependencies": {

--- a/packages/bridge/src/routes/market.ts
+++ b/packages/bridge/src/routes/market.ts
@@ -5,7 +5,7 @@
 import { Router, type Router as RouterType } from 'express';
 import { z } from 'zod';
 import { randomUUID } from 'crypto';
-import { submitTransaction, getStateMachine, getCheckpoint, keyPairFromPrivateKey, waitForFiber, getFiberSequenceNumber, getEpochProgress } from '../metagraph.js';
+import { submitTransaction, getStateMachine, getCheckpoint, keyPairFromPrivateKey, waitForFiber, getFiberSequenceNumber, waitForSequence, getEpochProgress } from '../metagraph.js';
 import { MarketType, MarketState, getMarketDefinition } from '@ottochain/sdk/apps/markets';
 
 export const marketRoutes: RouterType = Router();
@@ -256,6 +256,11 @@ marketRoutes.post('/open', async (req, res) => {
     console.log(`[market/open] Opening market ${input.marketId}`);
     const result = await submitTransaction(message, input.privateKey);
 
+    // Wait for DL1 to confirm the sequence increment before returning.
+    // This ensures rapid follow-up calls (e.g., commit immediately after open)
+    // will read the updated sequence number and avoid duplicate-seq rejections.
+    await waitForSequence(input.marketId, targetSequenceNumber + 1);
+
     res.json({
       hash: result.hash,
       marketId: input.marketId,
@@ -312,6 +317,9 @@ marketRoutes.post('/commit', async (req, res) => {
     console.log(`[market/commit] ${keyPair.address} committing ${input.amount} to ${input.marketId}`);
     const result = await submitTransaction(message, input.privateKey);
 
+    // Wait for DL1 to confirm the sequence increment before returning.
+    await waitForSequence(input.marketId, targetSequenceNumber + 1);
+
     res.json({
       hash: result.hash,
       marketId: input.marketId,
@@ -363,6 +371,9 @@ marketRoutes.post('/close', async (req, res) => {
 
     console.log(`[market/close] Closing market ${input.marketId}`);
     const result = await submitTransaction(message, input.privateKey);
+
+    // Wait for DL1 to confirm the sequence increment before returning.
+    await waitForSequence(input.marketId, targetSequenceNumber + 1);
 
     res.json({
       hash: result.hash,
@@ -420,6 +431,9 @@ marketRoutes.post('/resolve', async (req, res) => {
     console.log(`[market/resolve] ${keyPair.address} resolving ${input.marketId} with outcome: ${input.outcome}`);
     const result = await submitTransaction(message, input.privateKey);
 
+    // Wait for DL1 to confirm the sequence increment before returning.
+    await waitForSequence(input.marketId, targetSequenceNumber + 1);
+
     res.json({
       hash: result.hash,
       marketId: input.marketId,
@@ -475,6 +489,9 @@ marketRoutes.post('/finalize', async (req, res) => {
 
     console.log(`[market/finalize] Finalizing market ${input.marketId}`);
     const result = await submitTransaction(message, input.privateKey);
+
+    // Wait for DL1 to confirm the sequence increment before returning.
+    await waitForSequence(input.marketId, targetSequenceNumber + 1);
 
     res.json({
       hash: result.hash,
@@ -548,6 +565,9 @@ marketRoutes.post('/claim', async (req, res) => {
     console.log(`[market/claim] ${keyPair.address} claiming from ${input.marketId}`);
     const result = await submitTransaction(message, input.privateKey);
 
+    // Wait for DL1 to confirm the sequence increment before returning.
+    await waitForSequence(input.marketId, targetSequenceNumber + 1);
+
     res.json({
       hash: result.hash,
       marketId: input.marketId,
@@ -601,6 +621,9 @@ marketRoutes.post('/refund', async (req, res) => {
 
     console.log(`[market/refund] Refunding market ${input.marketId}`);
     const result = await submitTransaction(message, input.privateKey);
+
+    // Wait for DL1 to confirm the sequence increment before returning.
+    await waitForSequence(input.marketId, targetSequenceNumber + 1);
 
     res.json({
       hash: result.hash,
@@ -656,6 +679,9 @@ marketRoutes.post('/cancel', async (req, res) => {
 
     console.log(`[market/cancel] Cancelling market ${input.marketId}`);
     const result = await submitTransaction(message, input.privateKey);
+
+    // Wait for DL1 to confirm the sequence increment before returning.
+    await waitForSequence(input.marketId, targetSequenceNumber + 1);
 
     res.json({
       hash: result.hash,

--- a/packages/bridge/test/market-sequence.test.ts
+++ b/packages/bridge/test/market-sequence.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Regression Test: Bridge Sequence Number Tracking (Issue #109)
+ *
+ * Verifies that rapid successive transactions to the same market fiber
+ * each use an incrementing targetSequenceNumber rather than the same stale value.
+ *
+ * Before the fix, all transitions after the first returned the same seq (0 or N)
+ * because DL1 hadn't updated its onchain fiberCommits by the time the next route
+ * handler called getFiberSequenceNumber(). The fix adds waitForSequence() after
+ * each submitTransaction(), ensuring DL1 confirms the increment before the
+ * response is sent — so the next call always reads an up-to-date sequence.
+ *
+ * Requires a running OttoChain cluster + bridge:
+ *   BRIDGE_URL=http://localhost:3030
+ *   ML0_URL=http://localhost:9200
+ *   DL1_URL=http://localhost:9300
+ *
+ * Run:
+ *   pnpm test:sequence
+ *   # or
+ *   node --test --experimental-strip-types test/market-sequence.test.ts
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert';
+
+const BRIDGE_URL = process.env.BRIDGE_URL || 'http://localhost:3030';
+const ML0_URL    = process.env.ML0_URL    || 'http://localhost:9200';
+const DL1_URL    = process.env.DL1_URL    || 'http://localhost:9300';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface Wallet {
+  privateKey: string;
+  publicKey:  string;
+  address:    string;
+}
+
+interface OnChainState {
+  fiberCommits?: Record<string, { sequenceNumber?: number }>;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, options);
+  const text = await res.text();
+  if (!res.ok) throw new Error(`HTTP ${res.status} at ${url}: ${text}`);
+  return JSON.parse(text) as T;
+}
+
+async function post<T>(path: string, body: unknown): Promise<T> {
+  return fetchJson<T>(`${BRIDGE_URL}${path}`, {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body:    JSON.stringify(body),
+  });
+}
+
+async function makeWallet(): Promise<Wallet> {
+  return fetchJson<Wallet>(`${BRIDGE_URL}/agent/wallet`, { method: 'POST' });
+}
+
+/** Get the DL1 onchain sequence number for a fiber (0 if not yet committed). */
+async function dl1Sequence(fiberId: string): Promise<number> {
+  try {
+    const onChain = await fetchJson<OnChainState>(
+      `${DL1_URL}/data-application/v1/onchain`
+    );
+    return onChain?.fiberCommits?.[fiberId]?.sequenceNumber ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+/** Poll ML0 until state machine is in the expected state, or timeout. */
+async function waitForState(
+  fiberId: string,
+  expectedState: string,
+  timeoutMs = 45_000
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${ML0_URL}/data-application/v1/state-machines/${fiberId}`);
+      if (res.ok) {
+        const sm = await res.json() as { currentState?: { value?: string } };
+        if (sm.currentState?.value === expectedState) return true;
+      }
+    } catch { /* cluster not ready */ }
+    await new Promise(r => setTimeout(r, 1000));
+  }
+  return false;
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Regression: rapid successive transactions should not reuse the same sequence
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('Market sequence number tracking (regression #109)', () => {
+  let wallet: Wallet;
+  let marketId: string;
+
+  before(async () => {
+    wallet = await makeWallet();
+    console.log(`  Wallet: ${wallet.address}`);
+  });
+
+  it('should create a prediction market', async () => {
+    const result = await post<{ marketId: string; hash: string }>('/market/create', {
+      privateKey:  wallet.privateKey,
+      marketType:  'prediction',
+      title:       'Sequence regression test market',
+      description: 'Verifies that rapid transitions use distinct sequence numbers',
+      terms: {
+        question: 'Will the sequence bug be fixed?',
+        outcomes: ['yes', 'no'],
+      },
+    });
+
+    assert.ok(result.marketId, 'Missing marketId');
+    assert.ok(result.hash,     'Missing hash');
+    marketId = result.marketId;
+    console.log(`  ✓ Market created: ${marketId}`);
+  });
+
+  it('should open the market — DL1 sequence should advance to 1', async () => {
+    const result = await post<{ hash: string; status: string }>('/market/open', {
+      privateKey: wallet.privateKey,
+      marketId,
+    });
+
+    assert.ok(result.hash, 'Missing hash from /market/open');
+    assert.strictEqual(result.status, 'OPEN', `Expected status OPEN, got ${result.status}`);
+
+    // After /market/open returns, the fix guarantees DL1 has already processed
+    // the open transition. Sequence should now be 1.
+    const seq = await dl1Sequence(marketId);
+    assert.strictEqual(
+      seq, 1,
+      `DL1 sequence should be 1 after open, got ${seq} — sequence not yet propagated`
+    );
+    console.log(`  ✓ Market opened; DL1 sequence = ${seq}`);
+  });
+
+  it('should commit agent1 — DL1 sequence should advance to 2', async () => {
+    const agent1 = await makeWallet();
+
+    const result = await post<{ hash: string; amount: number }>('/market/commit', {
+      privateKey: agent1.privateKey,
+      marketId,
+      amount: 10,
+      data: { outcome: 'yes' },
+    });
+
+    assert.ok(result.hash,   'Missing hash from /market/commit (agent1)');
+    assert.strictEqual(result.amount, 10, 'Wrong amount returned');
+
+    const seq = await dl1Sequence(marketId);
+    assert.strictEqual(
+      seq, 2,
+      `DL1 sequence should be 2 after commit agent1, got ${seq} — REGRESSION: duplicate sequence!`
+    );
+    console.log(`  ✓ Agent1 committed; DL1 sequence = ${seq}`);
+  });
+
+  it('should commit agent2 immediately after — DL1 sequence should advance to 3', async () => {
+    // This is the core of the regression: submit agent2's commit WITHOUT any
+    // manual sleep. Before the fix, the bridge would still see seq=1 from DL1
+    // and send targetSequenceNumber=1, colliding with agent1's commit.
+    const agent2 = await makeWallet();
+
+    const result = await post<{ hash: string }>('/market/commit', {
+      privateKey: agent2.privateKey,
+      marketId,
+      amount: 5,
+      data: { outcome: 'no' },
+    });
+
+    assert.ok(result.hash, 'Missing hash from /market/commit (agent2)');
+
+    const seq = await dl1Sequence(marketId);
+    assert.strictEqual(
+      seq, 3,
+      `DL1 sequence should be 3 after commit agent2, got ${seq} — REGRESSION: duplicate sequence!`
+    );
+    console.log(`  ✓ Agent2 committed (no sleep between commits); DL1 sequence = ${seq}`);
+  });
+
+  it('should close the market — DL1 sequence should advance to 4', async () => {
+    const result = await post<{ hash: string; status: string }>('/market/close', {
+      privateKey: wallet.privateKey,
+      marketId,
+    });
+
+    assert.ok(result.hash, 'Missing hash from /market/close');
+    assert.strictEqual(result.status, 'CLOSED', `Expected status CLOSED, got ${result.status}`);
+
+    const seq = await dl1Sequence(marketId);
+    assert.strictEqual(
+      seq, 4,
+      `DL1 sequence should be 4 after close, got ${seq} — REGRESSION: duplicate sequence!`
+    );
+    console.log(`  ✓ Market closed; DL1 sequence = ${seq}`);
+  });
+
+  it('full lifecycle completes on ML0 with CLOSED state', async () => {
+    const reached = await waitForState(marketId, 'CLOSED');
+    assert.ok(
+      reached,
+      `Market ${marketId} did not reach CLOSED on ML0 within timeout — ` +
+      `some transactions were likely rejected due to sequence mismatch`
+    );
+    console.log(`  ✓ Market CLOSED on ML0 — all transitions accepted, sequence tracking verified ✨`);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #109 — Bridge sends same `targetSequenceNumber` for rapid successive transactions.

## Root Cause

Each market route handler independently calls `getFiberSequenceNumber(fiberId)` to read DL1's onchain sequence just before submitting. For rapid back-to-back calls (e.g. `open → commit → commit → close`), DL1 has not yet processed the previous transaction by the time the next request reads the sequence. Result: every handler sees the same stale value and all post-first transactions are rejected with a sequence mismatch.

> **Note:** PR #108 attempted a fix via retry logic but was based on a wrong diagnosis. This PR addresses the actual root cause.

## Fix

`waitForSequence()` already existed in `metagraph.ts` but was never called from route handlers. This PR wires it in after every `submitTransaction()` call in `market.ts`:

```ts
const targetSequenceNumber = await getFiberSequenceNumber(input.marketId);
// ... build message ...
const result = await submitTransaction(message, input.privateKey);
await waitForSequence(input.marketId, targetSequenceNumber + 1); // ← fix
```

This blocks the HTTP response until DL1 confirms the sequence has incremented, so any subsequent request will read an up-to-date value. **No new infrastructure required.**

## Changes

| File | Change |
|------|--------|
| `packages/bridge/src/routes/market.ts` | Import `waitForSequence`; call after submit in all 8 transition handlers (open, commit, close, resolve, finalize, claim, refund, cancel) |
| `packages/bridge/test/market-sequence.test.ts` | Regression test: open + two commits + close with **no sleep between calls**; asserts DL1 sequence = 1, 2, 3, 4 respectively |
| `packages/bridge/package.json` | Add `test:sequence` script |

## Testing

```bash
# With running cluster + bridge:
pnpm --filter @ottochain/bridge test:sequence
```

The regression test submits open → commit(agent1) → commit(agent2) → close in rapid succession and verifies that DL1's `fiberCommits[marketId].sequenceNumber` increments at each step.

## Trade-off

`waitForSequence` adds latency to each bridge response (bounded by DL1 sync time, typically 1–3s). This is acceptable — the bridge already calls `waitForFiber` on `/market/open` — and correctness is required over raw throughput here.