### PR TITLE
fix: use npm @ottochain/sdk instead of GitHub refs

### DIFF
--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@ottochain/shared": "workspace:*",
-    "@ottochain/sdk": "github:ottobot-ai/ottochain-sdk#main",
+    "@ottochain/sdk": "1.0.1",
     "@stardust-collective/dag4": "^2.8.1",
     "canonicalize": "^2.1.0",
     "express": "^4.18.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint src --ext .ts"
   },
   "dependencies": {
-    "@ottochain/sdk": "github:ottobot-ai/ottochain-sdk#main",
+    "@ottochain/sdk": "1.0.1",
     "@prisma/client": "^5.9.0",
     "ioredis": "^5.9.2",
     "zod": "^3.22.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
   packages/bridge:
     dependencies:
       '@ottochain/sdk':
-        specifier: github:ottobot-ai/ottochain-sdk#main
-        version: https://codeload.github.com/ottobot-ai/ottochain-sdk/tar.gz/d9d122da450bf5cc5ad74dc56eb1b81e76478ec8(@stardust-collective/dag4@2.8.1)
+        specifier: 1.0.1
+        version: 1.0.1(@stardust-collective/dag4@2.8.1)
       '@ottochain/shared':
         specifier: workspace:*
         version: link:../shared
@@ -194,8 +194,8 @@ importers:
   packages/shared:
     dependencies:
       '@ottochain/sdk':
-        specifier: github:ottobot-ai/ottochain-sdk#main
-        version: https://codeload.github.com/ottobot-ai/ottochain-sdk/tar.gz/d9d122da450bf5cc5ad74dc56eb1b81e76478ec8(@stardust-collective/dag4@2.8.1)
+        specifier: 1.0.1
+        version: 1.0.1(@stardust-collective/dag4@2.8.1)
       '@prisma/client':
         specifier: ^5.9.0
         version: 5.22.0(prisma@5.22.0)
@@ -566,9 +566,8 @@ packages:
   '@noble/secp256k1@1.7.2':
     resolution: {integrity: sha512-/qzwYl5eFLH8OWIecQWM31qld2g1NfjgylK+TNhqtaUKP37Nm+Y+z30Fjhw0Ct8p9yCQEm2N3W/AckdIb3SMcQ==}
 
-  '@ottochain/sdk@https://codeload.github.com/ottobot-ai/ottochain-sdk/tar.gz/d9d122da450bf5cc5ad74dc56eb1b81e76478ec8':
-    resolution: {tarball: https://codeload.github.com/ottobot-ai/ottochain-sdk/tar.gz/d9d122da450bf5cc5ad74dc56eb1b81e76478ec8}
-    version: 0.1.0
+  '@ottochain/sdk@1.0.1':
+    resolution: {integrity: sha512-Pnz1xvDwGvPbFr2fuxpAmG006q9duoLEj4HAnt5tkMKQxjQzT34kzqWzxFvil4N3Zj4lU+4chLGL7fK2H9E/JA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@stardust-collective/dag4': ^2.6.0
@@ -2393,7 +2392,7 @@ snapshots:
 
   '@noble/secp256k1@1.7.2': {}
 
-  '@ottochain/sdk@https://codeload.github.com/ottobot-ai/ottochain-sdk/tar.gz/d9d122da450bf5cc5ad74dc56eb1b81e76478ec8(@stardust-collective/dag4@2.8.1)':
+  '@ottochain/sdk@1.0.1(@stardust-collective/dag4@2.8.1)':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@stardust-collective/dag4': 2.8.1


### PR DESCRIPTION
## Summary
Services were using `github:ottobot-ai/ottochain-sdk#main` which caused version drift (lockfile showed different commits for different packages).

## Changes
- Changed to npm package `@ottochain/sdk: 1.0.1` matching versions.yaml
- Ensures consistent SDK version across all packages

## Testing
- `pnpm install` succeeds
- `pnpm build` succeeds
- CI will validate