### PR TITLE
feat(ci): use pre-built JARs from versions.yaml

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -194,7 +194,7 @@ jobs:
           # Pre-built JARs are already in modules/*/target/ (tessellation) and
           # /tmp/metagraph-dummy/modules/*/target/ (ottochain).
           # assembly.sh finds them, skips sbt, copies to docker/jars/, builds image.
-          SKIP_METAGRAPH_ASSEMBLY=true \
+          SKIP_METAGRAPH_ASSEMBLY=true PUBLISH=false \
             ./bin/compose-runner.sh --up --skip-assembly --metagraph=/tmp/metagraph-dummy --dl1
 
       - name: Verify key distribution


### PR DESCRIPTION
## Summary

Replaces the ~15 min sbt build step in integration tests with pre-built JAR downloads from GitHub Releases.

### Changes

- **versions.yaml integration**: Fetches component versions from `ottobot-ai/ottochain-deploy/versions.yaml` as single source of truth
- **Pre-built JARs**: Downloads tessellation JARs from `Constellation-Labs/tessellation` releases and OttoChain metagraph JARs from `scasplte2/ottochain` releases
- **No sbt/Java on runner**: Eliminates checkout of tessellation + ottochain source repos, Java setup, sbt setup, and all Scala compilation
- **Override support**: `workflow_dispatch` inputs allow testing against unreleased versions
- **Traceability**: Summary step shows exact versions used

### How it works

1. Fetches `versions.yaml` from deploy repo → resolves ottochain + tessellation versions
2. Downloads pre-built release JARs from both repos
3. Places JARs where compose-runner's `assembly.sh` expects them (`modules/*/target/`)
4. compose-runner finds existing JARs, skips sbt, copies to `docker/jars/`, builds Docker image
5. Cluster starts from pre-built artifacts — same JARs that get deployed to Hetzner

### Impact

- CI time: **~15 min faster** (JAR download ~30s vs sbt build ~15min)
- Disk usage: **~6GB less** (no .ivy2, .sbt cache, .class files)
- Reliability: Tests run against the **exact same artifacts** that get deployed
- Version consistency: All repos use `versions.yaml` as single source of truth