### PR TITLE
fix(bridge): normalize definition fields before metagraph submission

### DIFF
--- a/packages/bridge/src/metagraph.ts
+++ b/packages/bridge/src/metagraph.ts
@@ -175,19 +175,49 @@ function extractSequenceInfo(
  * @param privateKey - Wallet private key in hex format
  * @returns Transaction hash and optional ordinal
  */
+/**
+ * Normalize a CreateStateMachine message so the definition only contains
+ * fields the Scala StateMachineDefinition case class expects:
+ *   states, initialState, transitions, metadata
+ *
+ * Extra fields like `crossReferences` or `emits` (SDK documentation fields)
+ * cause decode failures in derevo-circe-magnolia on the metagraph side.
+ */
+function normalizeMessage(message: unknown): unknown {
+  const msg = message as Record<string, unknown>;
+  if (!msg.CreateStateMachine) return message;
+
+  const csm = msg.CreateStateMachine as Record<string, unknown>;
+  const def = csm.definition as Record<string, unknown> | undefined;
+  if (!def) return message;
+
+  // Keep only the fields Scala's StateMachineDefinition knows about
+  const { states, initialState, transitions, metadata } = def;
+  return {
+    CreateStateMachine: {
+      ...csm,
+      definition: { states, initialState, transitions, metadata: metadata ?? null },
+    },
+  };
+}
+
 export async function submitTransaction(
   message: unknown,
   privateKey: string
 ): Promise<TransactionResult> {
+  // Normalize to strip SDK-only fields (crossReferences, emits) that the
+  // metagraph's Scala decoder doesn't understand.
+  const normalizedMessage = normalizeMessage(message);
+
   // Sign using SDK's batchSign (same as e2e tests)
-  const signed = await batchSign(message, [privateKey], { isDataUpdate: true });
+  const signed = await batchSign(normalizedMessage, [privateKey], { isDataUpdate: true });
 
   // Wrap in DataTransactionRequest format expected by tessellation DL1
   const payload = { data: signed, fee: null };
 
-  const msgType = Object.keys(message as object)[0];
+  const msgType = Object.keys(normalizedMessage as object)[0];
   const dl1Urls = getDl1Urls();
-  const seqInfo = extractSequenceInfo(message);
+  const seqInfo = extractSequenceInfo(normalizedMessage);
 
   console.log(`[metagraph] Submitting ${msgType} to ${dl1Urls.length} DL1 node(s): ${dl1Urls.join(', ')}`);
   console.log(`[metagraph] Payload (truncated): ${JSON.stringify(payload).substring(0, 300)}...`);


### PR DESCRIPTION
Strip SDK-only fields (`crossReferences`, `emits`) from `CreateStateMachine` definitions before signing and submitting to DL1.

## Problem
The SDK's contract/escrow/market definitions include documentation fields like `crossReferences` at the top level of the definition object. The metagraph's Scala `StateMachineDefinition` case class only has: `states`, `initialState`, `transitions`, `metadata`. Extra fields cause decode failures with `derevo-circe-magnolia`.

This is why contract integration tests fail with `HTTP 400: Bad Request` while agent identity tests pass (identity definitions don't have `crossReferences`).

## Fix
Added `normalizeMessage()` in `metagraph.ts` that:
1. Detects `CreateStateMachine` messages
2. Strips definition down to only the 4 fields Scala expects
3. Ensures `metadata` defaults to `null` (magnolia requires explicit null for Option[None])

## Testing
- `pnpm build` passes
- Should unblock PRs #129, #119, #126