### PR TITLE
fix: bump @ottochain/sdk to 1.0.2

### DIFF
--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@ottochain/shared": "workspace:*",
-    "@ottochain/sdk": "1.0.1",
+    "@ottochain/sdk": "1.0.2",
     "@stardust-collective/dag4": "^2.8.1",
     "canonicalize": "^2.1.0",
     "express": "^4.18.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint src --ext .ts"
   },
   "dependencies": {
-    "@ottochain/sdk": "1.0.1",
+    "@ottochain/sdk": "1.0.2",
     "@prisma/client": "^5.9.0",
     "ioredis": "^5.9.2",
     "zod": "^3.22.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
   packages/bridge:
     dependencies:
       '@ottochain/sdk':
-        specifier: 1.0.1
-        version: 1.0.1(@stardust-collective/dag4@2.8.1)
+        specifier: 1.0.2
+        version: 1.0.2(@stardust-collective/dag4@2.8.1)
       '@ottochain/shared':
         specifier: workspace:*
         version: link:../shared
@@ -194,8 +194,8 @@ importers:
   packages/shared:
     dependencies:
       '@ottochain/sdk':
-        specifier: 1.0.1
-        version: 1.0.1(@stardust-collective/dag4@2.8.1)
+        specifier: 1.0.2
+        version: 1.0.2(@stardust-collective/dag4@2.8.1)
       '@prisma/client':
         specifier: ^5.9.0
         version: 5.22.0(prisma@5.22.0)
@@ -566,8 +566,8 @@ packages:
   '@noble/secp256k1@1.7.2':
     resolution: {integrity: sha512-/qzwYl5eFLH8OWIecQWM31qld2g1NfjgylK+TNhqtaUKP37Nm+Y+z30Fjhw0Ct8p9yCQEm2N3W/AckdIb3SMcQ==}
 
-  '@ottochain/sdk@1.0.1':
-    resolution: {integrity: sha512-Pnz1xvDwGvPbFr2fuxpAmG006q9duoLEj4HAnt5tkMKQxjQzT34kzqWzxFvil4N3Zj4lU+4chLGL7fK2H9E/JA==}
+  '@ottochain/sdk@1.0.2':
+    resolution: {integrity: sha512-HVBoAjHMyylHUepSLtvNhPSDRnHG51NofpTm/N7FMQRPxAg0lQ1lY8peZTrrZptI3XnBhIwV74I29maJh6B1gA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@stardust-collective/dag4': ^2.6.0
@@ -2392,7 +2392,7 @@ snapshots:
 
   '@noble/secp256k1@1.7.2': {}
 
-  '@ottochain/sdk@1.0.1(@stardust-collective/dag4@2.8.1)':
+  '@ottochain/sdk@1.0.2(@stardust-collective/dag4@2.8.1)':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@stardust-collective/dag4': 2.8.1


### PR DESCRIPTION
SDK 1.0.2 (ottobot-ai/ottochain-sdk#42) moves `crossReferences` into `metadata.crossReferences` and `emits` into `transition.metadata.emits` at the JSON source level.

Definitions now only contain the 4 fields the metagraph Scala `StateMachineDefinition` expects (`states`, `initialState`, `transitions`, `metadata`), fixing HTTP 400 rejections from DL1 on contract/escrow submissions.

This is the proper fix — replaces the closed PR #138 (which stripped fields instead of putting them in the right place).