### PR TITLE
chore: add Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "automated"
+    ignore:
+      # Exclude internal @ottochain workspace packages
+      - dependency-name: "@ottochain/*"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 10
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "automated"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
Adds Dependabot configuration to automate dependency updates across all OttoChain repositories.

## Changes
- Weekly automated PRs for outdated npm packages (JS repos) and GitHub Actions
- PRs labeled `dependencies` + `automated` for easy triage
- `chore(deps):` commit prefix for consistent changelogs
- Internal `@ottochain/*` workspace packages excluded from updates
- Max 10 open npm PRs, 5 GitHub Actions PRs at a time

## Acceptance Criteria
- [x] Dependabot configured in all 6 active repos
- [x] Weekly PRs for npm (JS repos) and GitHub Actions
- [x] PR title prefix: `chore(deps):`
- [x] Labels: `dependencies`, `automated` auto-applied
- [x] Internal `@ottochain/*` packages excluded
- [x] Config committed to each repo root (`.github/dependabot.yml`)

## Trello
Card: https://trello.com/c/699678344d3c68750ca7b5c8