### PR TITLE
ci: add Node.js matrix testing (v20, v22, v24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22, 24]
     
     steps:
       - uses: actions/checkout@v6
       
-      - name: Setup Node.js
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: ${{ matrix.node-version }}
       
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -29,8 +32,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.STORE_PATH }}
-          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: pnpm-${{ runner.os }}-
+          key: pnpm-${{ runner.os }}-node${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: pnpm-${{ runner.os }}-node${{ matrix.node-version }}-
       
       - name: Install dependencies
         run: pnpm install
@@ -46,14 +49,17 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22, 24]
     
     steps:
       - uses: actions/checkout@v6
       
-      - name: Setup Node.js
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: ${{ matrix.node-version }}
       
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -66,8 +72,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.STORE_PATH }}
-          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: pnpm-${{ runner.os }}-
+          key: pnpm-${{ runner.os }}-node${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: pnpm-${{ runner.os }}-node${{ matrix.node-version }}-
       
       - name: Install dependencies
         run: pnpm install
@@ -79,6 +85,7 @@ jobs:
         run: pnpm test:coverage
       
       - name: Upload coverage to Codecov
+        if: matrix.node-version == 20
         uses: codecov/codecov-action@v4
         with:
           files: ./packages/*/coverage/lcov.info


### PR DESCRIPTION
## Summary

Adds Node.js matrix testing to CI for ottochain-services. Mirrors the SDK change in the same PR batch.

## Changes

- `build` and `test` jobs now run against Node.js **20, 22, and 24**
- Node version shown in CI check name for debugging
- Coverage upload only triggers on Node 20 to avoid duplicate Codecov uploads
- `db-schema` job stays on Node 20 — Postgres schema validation is not Node-version-sensitive

## Acceptance Criteria
- [x] Matrix versions: [20, 22, 24]
- [x] All test jobs run against all matrix versions
- [x] Node version shown in CI check name
- [x] Any failing version blocks the PR
- [x] No test code changes — pure CI config

Trello: [Matrix testing for SDK (699678364b)](https://trello.com/c/699678364b76ed73b9acb6d2)

---
*PR by @ottobot-ai — @scasplte2 please review*