### PR TITLE
fix: Use nc for health checks and add Prometheus exporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ pnpm dev
 ### Using Docker Compose
 
 ```bash
+# Create shared network (required — shared with ottochain-deploy stack)
+docker network create ottochain 2>/dev/null || true
+
 # Start services (Gateway, Bridge, Indexer + Redis/Postgres)
 make up
 

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-# Generic HTTP health check for Docker healthcheck
-# Usage: healthcheck.sh <port>
-PORT=${1:-3000}
-node -e "fetch('http://localhost:${PORT}/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"


### PR DESCRIPTION
## Problem
1. Docker shows containers as `unhealthy` because `wget` isn't in alpine images
2. Prometheus alerts firing for missing exporters (postgres, redis, node)

## Solution

### Health Checks
Replace `wget` with `nc -z` (netcat) which is available in alpine:
```yaml
# Before
test: ["CMD", "wget", "-q", "--spider", "http://localhost:3030/health"]

# After  
test: ["CMD-SHELL", "nc -z localhost 3030 || exit 1"]
```

### Prometheus Exporters
Added three exporters for infrastructure visibility:

| Exporter | Port | Purpose |
|----------|------|---------|
| postgres-exporter | 9187 | PostgreSQL metrics |
| redis-exporter | 9121 | Redis metrics |
| node-exporter | 9100 | Host/container metrics |

These integrate with the existing Prometheus setup in ottochain-monitoring.

## Testing
```bash
# Verify nc is available
docker exec bridge which nc
/usr/bin/nc

# After deploy, verify exporters
curl http://localhost:9187/metrics  # postgres
curl http://localhost:9121/metrics  # redis
curl http://localhost:9100/metrics  # node
```