### PR TITLE
feat: add Prometheus /metrics endpoint to monitor

### DIFF
--- a/packages/monitor/package.json
+++ b/packages/monitor/package.json
@@ -14,6 +14,7 @@
     "@prisma/client": "^5.22.0",
     "express": "^4.21.2",
     "ioredis": "^5.9.3",
+    "prom-client": "^15.1.3",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/packages/monitor/src/index.ts
+++ b/packages/monitor/src/index.ts
@@ -16,6 +16,7 @@ import { HealthCollector } from './collector.js';
 import { MonitorCache } from './cache.js';
 import { CacheRefresher } from './refresher.js';
 import { storeEvent, getMonitoringActivity, getRestartHistory, closeEvents } from './events.js';
+import { updateMetrics, metricsHandler } from './metrics.js';
 
 // =============================================================================
 // Authentication
@@ -171,6 +172,9 @@ async function main(): Promise<void> {
   app.use(basicAuthMiddleware(auth));
   app.use(express.static(path.join(__dirname, '../public')));
   
+  // Prometheus metrics endpoint (no auth, before other routes)
+  app.get('/metrics', metricsHandler);
+
   // REST endpoints with caching
   app.get('/health', async (_, res) => {
     // Build health response with component statuses
@@ -560,6 +564,9 @@ async function main(): Promise<void> {
     
     console.log(`${icon} [${new Date().toISOString()}] Nodes: ${healthyNodes}/${health.nodes.length} | Services: ${healthyServices}/${health.services.length} | Ordinal: ${health.metagraph.snapshotOrdinal ?? '-'} | Fibers: ${health.metagraph.fiberCount ?? '-'}`);
     
+    // Update Prometheus metrics
+    updateMetrics(health.nodes, health.services, health.metagraph, overall);
+
     // Broadcast to WebSocket clients
     broadcast({
       type: 'status',

--- a/packages/monitor/src/metrics.ts
+++ b/packages/monitor/src/metrics.ts
@@ -1,0 +1,147 @@
+/**
+ * Prometheus metrics endpoint for the OttoChain monitor.
+ * 
+ * Exposes collector data as Prometheus gauges so Grafana can query
+ * metagraph health alongside infrastructure metrics.
+ */
+
+import client from 'prom-client';
+import type { NodeHealth, ServiceHealth, MetagraphMetrics } from './types.js';
+
+// Use a custom registry so we don't pollute the global one
+const registry = new client.Registry();
+
+// Default process/nodejs metrics
+client.collectDefaultMetrics({ register: registry, prefix: 'ottochain_monitor_' });
+
+// ---------- Node health ----------
+
+const nodeStatus = new client.Gauge({
+  name: 'ottochain_node_healthy',
+  help: '1 if node is healthy, 0 otherwise',
+  labelNames: ['name', 'type', 'url'] as const,
+  registers: [registry],
+});
+
+const nodeState = new client.Gauge({
+  name: 'ottochain_node_ready',
+  help: '1 if node state is Ready, 0 otherwise',
+  labelNames: ['name', 'type'] as const,
+  registers: [registry],
+});
+
+const nodeLatency = new client.Gauge({
+  name: 'ottochain_node_latency_ms',
+  help: 'Last health check latency in milliseconds',
+  labelNames: ['name', 'type'] as const,
+  registers: [registry],
+});
+
+const nodeClusterSize = new client.Gauge({
+  name: 'ottochain_node_cluster_size',
+  help: 'Number of peers in the node cluster',
+  labelNames: ['name', 'type'] as const,
+  registers: [registry],
+});
+
+const nodeOrdinal = new client.Gauge({
+  name: 'ottochain_node_ordinal',
+  help: 'Latest ordinal reported by node',
+  labelNames: ['name', 'type'] as const,
+  registers: [registry],
+});
+
+// ---------- Service health ----------
+
+const serviceStatus = new client.Gauge({
+  name: 'ottochain_service_healthy',
+  help: '1 if service is healthy, 0 otherwise',
+  labelNames: ['name', 'type'] as const,
+  registers: [registry],
+});
+
+const serviceLatency = new client.Gauge({
+  name: 'ottochain_service_latency_ms',
+  help: 'Last health check latency in milliseconds',
+  labelNames: ['name', 'type'] as const,
+  registers: [registry],
+});
+
+// ---------- Metagraph metrics ----------
+
+const snapshotOrdinal = new client.Gauge({
+  name: 'ottochain_metagraph_snapshot_ordinal',
+  help: 'Latest metagraph snapshot ordinal',
+  registers: [registry],
+});
+
+const fiberCount = new client.Gauge({
+  name: 'ottochain_metagraph_fiber_count',
+  help: 'Number of active fibers (state machines)',
+  registers: [registry],
+});
+
+const dl1Lag = new client.Gauge({
+  name: 'ottochain_metagraph_dl1_lag',
+  help: 'DL1 ordinal lag behind ML0',
+  registers: [registry],
+});
+
+const gl0Ordinal = new client.Gauge({
+  name: 'ottochain_metagraph_gl0_ordinal',
+  help: 'Global L0 ordinal',
+  registers: [registry],
+});
+
+const overallHealthy = new client.Gauge({
+  name: 'ottochain_overall_healthy',
+  help: '1 if overall status is healthy, 0 otherwise',
+  registers: [registry],
+});
+
+// ---------- Update function ----------
+
+export function updateMetrics(
+  nodes: NodeHealth[],
+  services: ServiceHealth[],
+  metagraph: MetagraphMetrics,
+  overall: string,
+): void {
+  // Nodes
+  for (const node of nodes) {
+    const labels = { name: node.name, type: node.type };
+    nodeStatus.set({ ...labels, url: node.url }, node.status === 'healthy' ? 1 : 0);
+    nodeState.set(labels, node.state === 'Ready' ? 1 : 0);
+    if (node.latencyMs !== undefined) nodeLatency.set(labels, node.latencyMs);
+    if (node.clusterSize !== undefined) nodeClusterSize.set(labels, node.clusterSize);
+    if (node.ordinal !== undefined) nodeOrdinal.set(labels, node.ordinal);
+  }
+
+  // Services
+  for (const svc of services) {
+    const labels = { name: svc.name, type: svc.type };
+    serviceStatus.set(labels, svc.status === 'healthy' ? 1 : 0);
+    if (svc.latencyMs !== undefined) serviceLatency.set(labels, svc.latencyMs);
+  }
+
+  // Metagraph
+  if (metagraph.snapshotOrdinal !== undefined) snapshotOrdinal.set(metagraph.snapshotOrdinal);
+  if (metagraph.fiberCount !== undefined) fiberCount.set(metagraph.fiberCount);
+  if (metagraph.dl1Lag !== undefined) dl1Lag.set(metagraph.dl1Lag);
+  if (metagraph.gl0Ordinal !== undefined) gl0Ordinal.set(metagraph.gl0Ordinal);
+
+  // Overall
+  overallHealthy.set(overall === 'healthy' ? 1 : 0);
+}
+
+// ---------- Express handler ----------
+
+export async function metricsHandler(_req: express.Request, res: express.Response): Promise<void> {
+  res.set('Content-Type', registry.contentType);
+  res.end(await registry.metrics());
+}
+
+// Need express types for the handler signature
+import type express from 'express';
+
+export { registry };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       ioredis:
         specifier: ^5.9.3
         version: 5.9.3
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       ws:
         specifier: ^8.18.0
         version: 8.19.0
@@ -233,7 +236,7 @@ importers:
         version: 25.3.0
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@25.3.0)(tsx@4.21.0))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(tsx@4.21.0))
       tsx:
         specifier: ^4.7.0
         version: 4.21.0
@@ -242,7 +245,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.3.0)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(tsx@4.21.0)
 
 packages:
 
@@ -568,6 +571,10 @@ packages:
 
   '@noble/secp256k1@1.7.2':
     resolution: {integrity: sha512-/qzwYl5eFLH8OWIecQWM31qld2g1NfjgylK+TNhqtaUKP37Nm+Y+z30Fjhw0Ct8p9yCQEm2N3W/AckdIb3SMcQ==}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@ottochain/sdk@1.1.1':
     resolution: {integrity: sha512-RGKqYEPo5sEnJKeccx8DoNw20IM05yQX+7kzScpYrcSOJIlZV4+QNMtVZuzdlC101B4ViwMGIt8TmRXbB+IXIw==}
@@ -949,6 +956,9 @@ packages:
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   bip39@3.1.0:
     resolution: {integrity: sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==}
@@ -1674,6 +1684,10 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -1872,6 +1886,9 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   timed-out@4.0.1:
     resolution: {integrity: sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==}
@@ -2399,6 +2416,8 @@ snapshots:
 
   '@noble/secp256k1@1.7.2': {}
 
+  '@opentelemetry/api@1.9.0': {}
+
   '@ottochain/sdk@1.1.1(@stardust-collective/dag4@2.8.1)':
     dependencies:
       '@bufbuild/protobuf': 2.11.0
@@ -2704,7 +2723,7 @@ snapshots:
     dependencies:
       '@types/node': 25.3.0
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.3.0)(tsx@4.21.0))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(tsx@4.21.0))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -2716,7 +2735,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@25.3.0)(tsx@4.21.0)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(tsx@4.21.0)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -2820,6 +2839,8 @@ snapshots:
       tweetnacl: 0.14.5
 
   bignumber.js@9.3.1: {}
+
+  bintrees@1.0.2: {}
 
   bip39@3.1.0:
     dependencies:
@@ -3612,6 +3633,11 @@ snapshots:
 
   process@0.11.10: {}
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      tdigest: 0.1.2
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -3903,6 +3929,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
+
   timed-out@4.0.1: {}
 
   tinybench@2.9.0: {}
@@ -4016,7 +4046,7 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.21.0
 
-  vitest@4.0.18(@types/node@25.3.0)(tsx@4.21.0):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.0)(tsx@4.21.0))
@@ -4039,6 +4069,7 @@ snapshots:
       vite: 7.3.1(@types/node@25.3.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 25.3.0
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
Adds a `/metrics` endpoint using `prom-client` so Prometheus can scrape metagraph health data directly from the monitor.

**Metrics exposed:**
- `ottochain_node_healthy`, `_ready`, `_latency_ms`, `_cluster_size`, `_ordinal` (per node, labeled by name/type)
- `ottochain_service_healthy`, `_latency_ms` (per service)
- `ottochain_metagraph_snapshot_ordinal`, `_fiber_count`, `_dl1_lag`, `_gl0_ordinal`
- `ottochain_overall_healthy`
- Default Node.js process metrics (prefixed `ottochain_monitor_`)

**Why:** Prometheus couldn't scrape the monitor (404 on /metrics). This was blocking the Grafana Operations dashboard from showing metagraph-level metrics.

**Companion PR:** ottobot-ai/ottochain-deploy#109 (adds monitor target back to Prometheus config)