### PR TITLE
fix(monitor): copy HTML files to dist on build

### DIFF
--- a/packages/monitor/package.json
+++ b/packages/monitor/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp src/*.html dist/",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js"
   },


### PR DESCRIPTION
TypeScript build only copies `.ts` files. The traffic-control and rejections HTML dashboards live in `src/` but Express resolves them via `__dirname` which points to `dist/` at runtime → 404.

Adds `cp src/*.html dist/` to the build step.

This is why `status.ottochain.ai/traffic` returns 404.