### PR TITLE
chore: release 1.0.3 (reconcile release-please with manual release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.0.3](https://github.com/ottobot-ai/ottochain-services/compare/v1.0.2...v1.0.3) (2026-06-25)
+
+
+### Miscellaneous
+
+* adopt @ottochain/sdk v2.4.0 — Metakit 1.8 drop-null content-hash convention ([#296](https://github.com/ottobot-ai/ottochain-services/issues/296))
+* batch dependabot dependency + GitHub Actions updates ([#298](https://github.com/ottobot-ai/ottochain-services/issues/298))
+
 ## [1.0.2](https://github.com/ottobot-ai/ottochain-services/compare/v1.0.1...v1.0.2) (2026-03-27)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ottochain-services",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "description": "OttoChain companion services - Gateway, Bridge, Indexer",
   "repository": {


### PR DESCRIPTION
Reconciles release-please state with the **manual `v1.0.3` release** (the SDK-2.4.0 services image published via `release.yml` dispatch, since release-please doesn't auto-cut on `chore` commits).

Mirrors a normal release-please release commit:
- `package.json` version `1.0.2 → 1.0.3`
- prepend the `1.0.3` CHANGELOG entry

Without this, release-please (release-type `node`, no manifest) still thinks 1.0.2 is the latest and would mis-compute the next version against the now-published `v1.0.3` tag.

1.0.3 contents: `@ottochain/sdk` v2.4.0 adoption (#296) + batched dependabot updates (#298).

🤖 Generated with [Claude Code](https://claude.com/claude-code)