### PR TITLE
ci(e2e): drop temporary METAGRAPH_VERSION_OVERRIDE (versions.yaml now 0.7.16)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,10 +24,6 @@ on:
 
 env:
   NODE_VERSION: '20'
-  # TEMPORARY e2e pin: validate services (SDK 2.4.0 / Metakit 1.8) against metagraph 0.7.16
-  # while the deployed version in ottochain-deploy/versions.yaml is still 0.7.13 (Metakit 1.7).
-  # Remove once deploy PR ottobot-ai/ottochain-deploy#232 lands 0.7.16.
-  METAGRAPH_VERSION_OVERRIDE: '0.7.16'
 
 jobs:
   integration-test:
@@ -213,10 +209,6 @@ jobs:
             -o versions.yaml
 
           OTTOCHAIN_VER=$(grep -A1 'ottochain:' versions.yaml | grep 'version:' | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          if [ -n "${METAGRAPH_VERSION_OVERRIDE:-}" ]; then
-            echo "⚠️ e2e override: metagraph ${OTTOCHAIN_VER} → ${METAGRAPH_VERSION_OVERRIDE} (SDK 2.4.0 / Metakit 1.8 validation)"
-            OTTOCHAIN_VER="${METAGRAPH_VERSION_OVERRIDE}"
-          fi
           TESS_VER=$(grep -A1 'tessellation:' versions.yaml | grep 'version:' | head -1 | sed 's/.*"\(.*\)".*/\1/')
           [[ "$TESS_VER" != v* ]] && TESS_VER="v${TESS_VER}"
 


### PR DESCRIPTION
Removes the temporary `METAGRAPH_VERSION_OVERRIDE: '0.7.16'` (env var + the override branch in the released version-resolution step) added during the SDK 2.4.0 / Metakit 1.8 cutover.

It was needed while `ottochain-deploy/versions.yaml` still pinned metagraph **0.7.13** but services were on SDK 2.4.0 — it forced the e2e to validate against 0.7.16. Now that `versions.yaml` carries **0.7.16 + services 1.0.3**, the override is redundant: the released path reads `OTTOCHAIN_VER` straight from `versions.yaml` again, so the e2e tracks the **actual deployed** metagraph version (and would correctly fail on a future mismatch instead of silently masking it).

**Behavior unchanged today** — `versions.yaml` resolves to 0.7.16, exactly what the override forced (and what the green validation run used).

Retained: the `--hypergraph-release=v4.0.0-rc.10` pin on the released cluster runner — it matches `versions.yaml`'s `tessellation: 4.0.0-rc.10` and was part of the validated config. (Could be parameterized to `${{ steps.versions-released.outputs.tessellation }}` as a later tidy-up; left as-is here to keep this PR scoped to the override.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)