### PR TITLE
chore(deps): bump @ottochain/sdk to v2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typescript": "^6.0.2"
   },
   "dependencies": {
-    "@ottochain/sdk": "2.4.0",
+    "@ottochain/sdk": "2.7.0",
     "@prisma/client": "^7.6.0",
     "ioredis": "^5.10.0"
   },

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -14,7 +14,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@ottochain/sdk": "2.4.0",
+    "@ottochain/sdk": "2.7.0",
     "@ottochain/shared": "workspace:*",
     "@stardust-collective/dag4": "^2.8.1",
     "canonicalize": "^2.1.0",

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -12,7 +12,7 @@
     "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "dependencies": {
-    "@ottochain/sdk": "2.4.0",
+    "@ottochain/sdk": "2.7.0",
     "@ottochain/shared": "workspace:*",
     "@prisma/client": "^7.6.0",
     "express": "^4.18.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint src --ext .ts"
   },
   "dependencies": {
-    "@ottochain/sdk": "2.4.0",
+    "@ottochain/sdk": "2.7.0",
     "@prisma/adapter-pg": "^7.6.0",
     "@prisma/client": "^7.6.0",
     "ioredis": "^5.9.3",

--- a/packages/traffic-generator/package.json
+++ b/packages/traffic-generator/package.json
@@ -16,7 +16,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@ottochain/sdk": "2.4.0",
+    "@ottochain/sdk": "2.7.0",
     "@ottochain/shared": "workspace:*",
     "@stardust-collective/dag4": "^2.8.1",
     "dotenv": "^17.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@ottochain/sdk':
-        specifier: 2.4.0
-        version: 2.4.0(@stardust-collective/dag4@2.8.1)
+        specifier: 2.7.0
+        version: 2.7.0(@stardust-collective/dag4@2.8.1)
       '@prisma/client':
         specifier: ^7.6.0
         version: 7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3)
@@ -40,8 +40,8 @@ importers:
   packages/bridge:
     dependencies:
       '@ottochain/sdk':
-        specifier: 2.4.0
-        version: 2.4.0(@stardust-collective/dag4@2.8.1)
+        specifier: 2.7.0
+        version: 2.7.0(@stardust-collective/dag4@2.8.1)
       '@ottochain/shared':
         specifier: workspace:*
         version: link:../shared
@@ -150,8 +150,8 @@ importers:
   packages/indexer:
     dependencies:
       '@ottochain/sdk':
-        specifier: 2.4.0
-        version: 2.4.0(@stardust-collective/dag4@2.8.1)
+        specifier: 2.7.0
+        version: 2.7.0(@stardust-collective/dag4@2.8.1)
       '@ottochain/shared':
         specifier: workspace:*
         version: link:../shared
@@ -221,8 +221,8 @@ importers:
   packages/shared:
     dependencies:
       '@ottochain/sdk':
-        specifier: 2.4.0
-        version: 2.4.0(@stardust-collective/dag4@2.8.1)
+        specifier: 2.7.0
+        version: 2.7.0(@stardust-collective/dag4@2.8.1)
       '@prisma/adapter-pg':
         specifier: ^7.6.0
         version: 7.8.0
@@ -252,8 +252,8 @@ importers:
   packages/traffic-generator:
     dependencies:
       '@ottochain/sdk':
-        specifier: 2.4.0
-        version: 2.4.0(@stardust-collective/dag4@2.8.1)
+        specifier: 2.7.0
+        version: 2.7.0(@stardust-collective/dag4@2.8.1)
       '@ottochain/shared':
         specifier: workspace:*
         version: link:../shared
@@ -396,16 +396,16 @@ packages:
   '@bufbuild/protobuf@2.12.1':
     resolution: {integrity: sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==}
 
-  '@constellation-network/metagraph-sdk-core@1.8.0-rc.5':
-    resolution: {integrity: sha512-B+3afI/xOOE/mH7NbdUwXiX9GuA/rFMWci1OHnU+kFKTfVV1sHnxsIelKhm/bcG/N/AsxzQ8IpesJwKZr4FPpA==}
+  '@constellation-network/metagraph-sdk-core@1.8.0-rc.7':
+    resolution: {integrity: sha512-dshRWUlVES5W4JnouDrXxHmN1n5Ma83801sQo48jhp4GAPMNHL48k9s1VS6QbW6R4B8340yXR5HbGFdOPOB1RA==}
     engines: {node: '>=20.19.0'}
 
-  '@constellation-network/metagraph-sdk-jlvm@1.8.0-rc.5':
-    resolution: {integrity: sha512-IHiGMdlyyW9v4b8kyRQNCAwdKBKd5CI8EzUgJtk/JlO19eHZ69hYjPDDX4Pkwe7OqClAY8WBqDXC/5ZLn2+15A==}
+  '@constellation-network/metagraph-sdk-jlvm@1.8.0-rc.7':
+    resolution: {integrity: sha512-eMzJGMCO9zWsS/+EMuhQSKaJZplFLh0QiQZqS66xdx6lqitxGFfFEBLcrfENthECxdxS+7Q1hTPL9TWnS0ejUw==}
     engines: {node: '>=20.19.0'}
 
-  '@constellation-network/metagraph-sdk@1.8.0-rc.5':
-    resolution: {integrity: sha512-/3zAJ+IaSl8l9MMVkjudAjeoh1QiR4r47jt+aIuy4b0o2sL1rueDGC5itTDb8+qY/A499JoWk+2abR4zZni9TA==}
+  '@constellation-network/metagraph-sdk@1.8.0-rc.7':
+    resolution: {integrity: sha512-/8mYIHhwQrIPbGK9Def29fXUVv8hDvyLTJKqWnIK5FCjVndexEqJxoGsmZZVUhZtxpvw+KxjnfqkPwcOTGEgww==}
     engines: {node: '>=20.19.0'}
 
   '@electric-sql/pglite-socket@0.1.1':
@@ -654,8 +654,8 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
-  '@ottochain/sdk@2.4.0':
-    resolution: {integrity: sha512-+yBkZd8HKFEJNHWxj1nYGLx+Ix+WahndUZRUR2R61FM7pZN+61nNxzJuktlm3PMZbIDVqLQ1PHHlhupgARKq8Q==}
+  '@ottochain/sdk@2.7.0':
+    resolution: {integrity: sha512-hd2esfC2QWuBATxaxzfPGFTIyGHjxaus4Il0BDRL8CnDT/ChR2logDAnbt+X9R0Vvs3y/F2Je/gntZBEzci/xw==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@stardust-collective/dag4': ^2.6.0
@@ -2569,11 +2569,12 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   valibot@1.2.0:
@@ -2878,20 +2879,20 @@ snapshots:
 
   '@bufbuild/protobuf@2.12.1': {}
 
-  '@constellation-network/metagraph-sdk-core@1.8.0-rc.5':
+  '@constellation-network/metagraph-sdk-core@1.8.0-rc.7':
     dependencies:
       '@noble/curves': 2.0.1
       '@noble/hashes': 2.0.1
       bs58: 6.0.0
 
-  '@constellation-network/metagraph-sdk-jlvm@1.8.0-rc.5':
+  '@constellation-network/metagraph-sdk-jlvm@1.8.0-rc.7':
     dependencies:
       '@noble/curves': 2.0.1
       '@noble/hashes': 2.0.1
 
-  '@constellation-network/metagraph-sdk@1.8.0-rc.5':
+  '@constellation-network/metagraph-sdk@1.8.0-rc.7':
     dependencies:
-      '@constellation-network/metagraph-sdk-core': 1.8.0-rc.5
+      '@constellation-network/metagraph-sdk-core': 1.8.0-rc.7
       '@noble/hashes': 2.0.1
 
   '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':
@@ -3059,11 +3060,11 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
-  '@ottochain/sdk@2.4.0(@stardust-collective/dag4@2.8.1)':
+  '@ottochain/sdk@2.7.0(@stardust-collective/dag4@2.8.1)':
     dependencies:
       '@bufbuild/protobuf': 2.12.1
-      '@constellation-network/metagraph-sdk': 1.8.0-rc.5
-      '@constellation-network/metagraph-sdk-jlvm': 1.8.0-rc.5
+      '@constellation-network/metagraph-sdk': 1.8.0-rc.7
+      '@constellation-network/metagraph-sdk-jlvm': 1.8.0-rc.7
       '@noble/hashes': 1.8.0
       '@stardust-collective/dag4': 2.8.1
       '@stardust-collective/dag4-keystore': 2.8.1


### PR DESCRIPTION
Automated SDK version bump triggered by `@ottochain/sdk` release.

## Changes
- `@ottochain/sdk` → `v2.7.0`

## Updated packages
All workspace packages that depend on `@ottochain/sdk` have been updated.

---
*Triggered by: repository_dispatch*
*Auto-merge enabled: will merge when CI passes*